### PR TITLE
✨ Updating people & roles tab to include images from SSW people

### DIFF
--- a/.claude/skills/process-transcript/SKILL.md
+++ b/.claude/skills/process-transcript/SKILL.md
@@ -108,7 +108,8 @@ Create `projects/{project}/dashboards/{date}/index.html` using the **consolidate
 - Energy level indicators
 
 #### Tab 3: People & Roles
-- Participant cards (canonical names with roles as subtitle)
+- Participant cards with **profile photos from SSW People** (with fallback initials for non-SSW)
+- Canonical names with roles as subtitle
 - Speaking time visualization
 - Value contribution ratings
 - Strengths and feedback for each person

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/{Person
             <img src="https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/Bob-Northwind/Images/Bob-Northwind-Profile.jpg"
                  alt="Bob Northwind"
                  class="profile-image"
-                 onerror="var placeholder=document.createElement('div');placeholder.className='profile-image-placeholder';placeholder.textContent='BN';this.replaceWith(placeholder);">
+                 onerror="var placeholder=document.createElement('div');var name=this.getAttribute('aria-label')||this.alt;placeholder.className='profile-image-placeholder';placeholder.textContent='BN';if(name){placeholder.setAttribute('role','img');placeholder.setAttribute('aria-label',name);}this.replaceWith(placeholder);">
         </div>
 
         <!-- Info Section -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -216,7 +216,7 @@ https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/{Person
             <img src="https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/Bob-Northwind/Images/Bob-Northwind-Profile.jpg"
                  alt="Bob Northwind"
                  class="profile-image"
-                 onerror="this.parentElement.innerHTML='<div class=\'profile-image-placeholder\'>BN</div>'">
+                 onerror="var placeholder=document.createElement('div');placeholder.className='profile-image-placeholder';placeholder.textContent='BN';this.replaceWith(placeholder);">
         </div>
 
         <!-- Info Section -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,9 +215,24 @@ https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/{Person
         <div class="profile-image-container">
             <img src="https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/Bob-Northwind/Images/Bob-Northwind-Profile.jpg"
                  alt="Bob Northwind"
-                 class="profile-image"
-                 onerror="var placeholder=document.createElement('div');var name=this.getAttribute('aria-label')||this.alt;placeholder.className='profile-image-placeholder';placeholder.textContent='BN';if(name){placeholder.setAttribute('role','img');placeholder.setAttribute('aria-label',name);}this.replaceWith(placeholder);">
+                 class="profile-image js-profile-image"
+                 data-initials="BN">
         </div>
+        <script>
+            // Handle profile image load failures without using inline JavaScript.
+            // The initials shown in the placeholder MUST come from trusted participant data.
+            document.addEventListener('DOMContentLoaded', function () {
+                document.querySelectorAll('.js-profile-image').forEach(function (img) {
+                    img.addEventListener('error', function () {
+                        var initials = img.getAttribute('data-initials') || '';
+                        var placeholder = document.createElement('div');
+                        placeholder.className = 'profile-image-placeholder';
+                        placeholder.textContent = initials;
+                        img.replaceWith(placeholder);
+                    });
+                });
+            });
+        </script>
 
         <!-- Info Section -->
         <div class="flex-1">

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,6 +98,7 @@ The dashboard MUST have these tabs (all using consolidated data):
 
 ### Tab 3: People & Roles
 - Card for each participant **(canonical name with role as subtitle)**
+- **Profile photo from SSW People** (with fallback for non-SSW participants)
 - Speaking time vs. value contribution
 - Strengths and constructive feedback
 
@@ -163,6 +164,104 @@ Use data from `consolidated.json -> speakerTimeline -> participants[]` to genera
 - Use class `short` for < 30s, `medium` for 30s-2m, `long` for > 2m
 
 **Sort participants by total speaking time (descending)**
+
+### Participant Cards with Profile Photos
+
+The `{{PARTICIPANT_CARDS}}` placeholder must be populated with HTML cards for each participant, including their SSW profile photo.
+
+#### SSW Profile Photo URL Pattern
+
+Profile photos are stored in the SSW.People.Profiles GitHub repository:
+
+```
+https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/{Person-Name}/Images/{Person-Name}-Profile.jpg
+```
+
+**Name Conversion Rules:**
+- Convert spaces to hyphens: "Bob Northwind" → "Bob-Northwind"
+- Preserve capitalization: "Adam Cogan" → "Adam-Cogan"
+- Use full name as stored in SSW People
+
+#### Participant Card HTML Structure
+
+```html
+<div class="bg-white rounded-xl shadow-sm ssw-card p-6">
+    <div class="flex gap-4">
+        <!-- Profile Photo -->
+        <div class="profile-image-container">
+            <img src="https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/Bob-Northwind/Images/Bob-Northwind-Profile.jpg"
+                 alt="Bob Northwind"
+                 class="profile-image"
+                 onerror="this.parentElement.innerHTML='<div class=\'profile-image-placeholder\'>BN</div>'">
+        </div>
+
+        <!-- Info Section -->
+        <div class="flex-1">
+            <div class="flex items-start justify-between mb-2">
+                <div>
+                    <h3 class="font-bold text-ssw-charcoal text-lg">Bob Northwind</h3>
+                    <p class="text-ssw-gray-500 text-sm">Senior Developer</p>
+                </div>
+                <span class="bg-ssw-gray-100 text-ssw-gray-700 px-2 py-1 rounded text-sm font-medium">
+                    18% speaking time
+                </span>
+            </div>
+
+            <!-- Value Score -->
+            <div class="mb-3">
+                <div class="flex items-center gap-2">
+                    <span class="text-sm text-ssw-gray-600">Value Score:</span>
+                    <div class="flex-1 bg-ssw-gray-100 rounded-full h-2">
+                        <div class="bg-ssw-red h-2 rounded-full" style="width: 85%"></div>
+                    </div>
+                    <span class="text-sm font-semibold text-ssw-charcoal">8.5/10</span>
+                </div>
+            </div>
+
+            <!-- Key Finding -->
+            <p class="text-sm text-ssw-gray-600 mb-3">
+                <span class="font-medium text-ssw-charcoal">Key finding:</span>
+                Highest value-per-minute but systematically underutilized
+            </p>
+
+            <!-- Strengths -->
+            <div class="mb-2">
+                <p class="text-xs font-semibold text-green-700 uppercase tracking-wide mb-1">Strengths</p>
+                <ul class="text-sm text-ssw-gray-600 space-y-1">
+                    <li>• Efficient communication - every word counted</li>
+                    <li>• Technical expertise highly valuable when consulted</li>
+                </ul>
+            </div>
+
+            <!-- Feedback -->
+            <div>
+                <p class="text-xs font-semibold text-ssw-red uppercase tracking-wide mb-1">Feedback</p>
+                <ul class="text-sm text-ssw-gray-600 space-y-1">
+                    <li>• Push back when interrupted - your points are important</li>
+                    <li>• Don't wait for permission to contribute</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+```
+
+#### Fallback for Non-SSW Participants
+
+For participants who don't have SSW profiles, use their initials as a fallback:
+
+```html
+<div class="profile-image-container">
+    <div class="profile-image-placeholder">JD</div>
+</div>
+```
+
+The `onerror` handler on the `<img>` tag automatically falls back to initials when the image fails to load.
+
+**Initials Calculation:**
+- "John Doe" → "JD"
+- "Alice Smith" → "AS"
+- Single name "Charlie" → "C"
 
 ## DO NOT
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -177,6 +177,35 @@
         .grade-c { background: #F59E0B; }
         .grade-d { background: #DC2626; }
         .grade-f { background: #7F1D1D; }
+
+        /* Profile image styles */
+        .profile-image-container {
+            width: 80px;
+            height: 100px;
+            overflow: hidden;
+            border-radius: 8px;
+            background: #E4E4E7;
+            flex-shrink: 0;
+        }
+
+        .profile-image {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            object-position: top center;
+        }
+
+        .profile-image-placeholder {
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #E4E4E7 0%, #D4D4D8 100%);
+            color: #71717A;
+            font-size: 2rem;
+            font-weight: 600;
+        }
     </style>
 </head>
 <body class="bg-ssw-gray-50 min-h-screen">


### PR DESCRIPTION
Changes Made
- Added an additional display on the People & Roles tab to display the people's profile picture from SSW People, defaulting to their initials if a person cannot be found.