### PR TITLE
Fix invitee matching to expand first names to full names

### DIFF
--- a/.claude/agents/consolidator.md
+++ b/.claude/agents/consolidator.md
@@ -23,7 +23,9 @@ This is non-negotiable. Create a canonical name mapping:
 
 #### Resolution Priority
 1. **`<v>` speaker tags are authoritative** — always use the tagged name as canonical, even if the person is not on the invite list
-2. **Invite list for correction** — when transcript text mentions a name (e.g., "Thiago") with no `<v>` tag, match against `attendees.json` invitees for the correct spelling (e.g., "Tiago Araujo" from UPN `TiagoAraujo@ssw.com.au`)
+2. **Invite list for name resolution** — when transcript text mentions someone by name (e.g., "Thiago", "Alex") with no `<v>` tag, match against `attendees.json` invitees for:
+   - **Spelling correction**: "Thiago" → "Tiago Araujo" (from UPN `TiagoAraujo@ssw.com.au`)
+   - **First-name-to-full-name expansion**: "Alex" → "Alex Torres" (from UPN `AlexTorres@ssw.com.au`). Even when the first name is spelled correctly, always look up the full name from the invitees list. With a small invite list of 6-10 people, a first-name match is almost always the right person.
 3. **Never override `<v>` tags with invite list** — a speaker with tags who isn't on the invite list still gets their tagged name
 
 #### Rules

--- a/.claude/agents/consolidator.md
+++ b/.claude/agents/consolidator.md
@@ -25,7 +25,7 @@ This is non-negotiable. Create a canonical name mapping:
 1. **`<v>` speaker tags are authoritative** — always use the tagged name as canonical, even if the person is not on the invite list
 2. **Invite list for name resolution** — when transcript text mentions someone by name (e.g., "Thiago", "Alex") with no `<v>` tag, match against `attendees.json` invitees for:
    - **Spelling correction**: "Thiago" → "Tiago Araujo" (from UPN `TiagoAraujo@ssw.com.au`)
-   - **First-name-to-full-name expansion**: "Alex" → "Alex Torres" (from UPN `AlexTorres@ssw.com.au`). Even when the first name is spelled correctly, always look up the full name from the invitees list. With a small invite list of 6-10 people, a first-name match is almost always the right person.
+   - **First-name-to-full-name expansion**: "Alex" → "Alex Blum" (from UPN `AlexBlum@ssw.com.au`). Even when the first name is spelled correctly, always look up the full name from the invitees list. With a small invite list of 6-10 people, a first-name match is almost always the right person.
 3. **Never override `<v>` tags with invite list** — a speaker with tags who isn't on the invite list still gets their tagged name
 
 #### Rules

--- a/.claude/agents/people-analyzer.md
+++ b/.claude/agents/people-analyzer.md
@@ -256,7 +256,9 @@ If an `attendees.json` file is available, read it for context. It contains:
 
 **Resolution priority:**
 1. **`<v>` tags are authoritative** — always use the tagged name, even if the person is not on the invite list
-2. **Invite list for name correction** — when transcript text mentions someone (e.g., "Gryphon") but they have no `<v>` tag, match against the invite list for the correct spelling (e.g., "Griffen")
+2. **Invite list for name resolution** — when transcript text mentions someone (e.g., "Gryphon", "Alex") but they have no `<v>` tag, match against the invite list for:
+   - **Spelling correction**: "Gryphon" → "Griffen Edge" (from invite list)
+   - **First-name-to-full-name expansion**: "Alex" → "Alex Torres" (from invite list). Even when the first name is already spelled correctly, always look up the full derived name from `attendees.json`. With a small invite list, a first-name match is almost always the right person.
 3. **Never override `<v>` tag data** — a speaker with tags who isn't on the invite list still gets a full participant card
 
 **Who gets a participant card:**

--- a/.claude/agents/people-analyzer.md
+++ b/.claude/agents/people-analyzer.md
@@ -258,7 +258,7 @@ If an `attendees.json` file is available, read it for context. It contains:
 1. **`<v>` tags are authoritative** — always use the tagged name, even if the person is not on the invite list
 2. **Invite list for name resolution** — when transcript text mentions someone (e.g., "Gryphon", "Alex") but they have no `<v>` tag, match against the invite list for:
    - **Spelling correction**: "Gryphon" → "Griffen Edge" (from invite list)
-   - **First-name-to-full-name expansion**: "Alex" → "Alex Torres" (from invite list). Even when the first name is already spelled correctly, always look up the full derived name from `attendees.json`. With a small invite list, a first-name match is almost always the right person.
+   - **First-name-to-full-name expansion**: "Alex" → "Alex Blum" (from invite list). Even when the first name is already spelled correctly, always look up the full derived name from `attendees.json`. With a small invite list, a first-name match is almost always the right person.
 3. **Never override `<v>` tag data** — a speaker with tags who isn't on the invite list still gets a full participant card
 
 **Who gets a participant card:**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,7 +72,7 @@ When processing a transcript, you have two data sources for identifying particip
 1. **`<v>` tags always win** — if someone has speaker tags, use their tagged name as canonical. This applies even if they are not on the invite list.
 2. **Invite list for name resolution** — when the transcript text mentions someone by name (e.g., "Gryphon", "Alex") but they have no `<v>` tag, match against the invite list for:
    - **Spelling correction**: "Gryphon" → "Griffen Edge", "Thiago" → "Tiago Araujo"
-   - **First-name-to-full-name expansion**: "Alex" → "Alex Torres" (from UPN `AlexTorres@ssw.com.au`). Even when the first name is already spelled correctly, always look up the **full derived name** from the invitees list. With a small invite list of 6-10 people, a first-name match is almost always the right person.
+   - **First-name-to-full-name expansion**: "Alex" → "Alex Blum" (from UPN `AlexBlum@ssw.com.au`). Even when the first name is already spelled correctly, always look up the **full derived name** from the invitees list. With a small invite list of 6-10 people, a first-name match is almost always the right person.
 3. **Unknown speakers** — if a name appears in transcript text but has no `<v>` tag and no plausible invite list match, do NOT create a participant card for them. They are likely being referenced in conversation but were not actually in the meeting.
 
 ### Who Gets a Participant Card

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,12 +65,14 @@ You are a meeting transcript processor. Your job is to convert .vtt transcripts 
 When processing a transcript, you have two data sources for identifying participants:
 
 1. **VTT `<v>` speaker tags** (e.g., `<v Tiago Araujo [SSW]>...`) — these are **authoritative**. Always use them, even if the person is not on the invite list.
-2. **Attendees file** (`attendees.json` in the meeting folder) — this contains the meeting invite list with names derived from UPNs. Use it as a **suggestion** for resolving misspelled names from transcript text, NOT as a source of truth for who attended.
+2. **Attendees file** (`attendees.json` in the meeting folder) — this contains the meeting invite list with names derived from UPNs. Use it as a **suggestion** for resolving names from transcript text, NOT as a source of truth for who attended.
 
 ### Resolution Priority
 
 1. **`<v>` tags always win** — if someone has speaker tags, use their tagged name as canonical. This applies even if they are not on the invite list.
-2. **Invite list for name correction** — when the transcript text mentions someone by name (e.g., "Gryphon", "Thiago") but they have no `<v>` tag, match against the invite list to find the correct spelling (e.g., "Griffen", "Tiago"). With a small invite list of 6-10 people, even badly misspelled names have an obvious closest match.
+2. **Invite list for name resolution** — when the transcript text mentions someone by name (e.g., "Gryphon", "Alex") but they have no `<v>` tag, match against the invite list for:
+   - **Spelling correction**: "Gryphon" → "Griffen Edge", "Thiago" → "Tiago Araujo"
+   - **First-name-to-full-name expansion**: "Alex" → "Alex Torres" (from UPN `AlexTorres@ssw.com.au`). Even when the first name is already spelled correctly, always look up the **full derived name** from the invitees list. With a small invite list of 6-10 people, a first-name match is almost always the right person.
 3. **Unknown speakers** — if a name appears in transcript text but has no `<v>` tag and no plausible invite list match, do NOT create a participant card for them. They are likely being referenced in conversation but were not actually in the meeting.
 
 ### Who Gets a Participant Card


### PR DESCRIPTION
## 📝 Summary of Changes

Corresponding issue: #31
- Boardroom participants who speak through someone else's mic (no `<v>` tag, first name only in transcript) now resolve to their full invite-list name and get an SSW profile photo card, instead of appearing as a first-name-only card with no photo.

### 🤷‍♂️ Why
The original fix for #31 only handled spelling correction (e.g. "Gryphon" -> "Griffen Edge"), so a correctly-spelled first name like "Alex" was left untouched and never got expanded to "Alex Torres" from the invite list. That meant boardroom attendees still slipped through with broken cards. This change instructs the agents to always complete first names to full names from `attendees.json`, not just correct misspellings.

### 🧪 Test plan
- [ ] Re-run the SSW Design meeting transcript to verify Alex and Pravin get full-name cards with profile photos
- [ ] Verify existing spelling correction scenarios still work (e.g. "Gryphon" -> "Griffen Edge")
- [ ] Verify `<v>` tag names still take priority over invite list names

🤖 Generated with [Claude Code](https://claude.com/claude-code)