### PR TITLE
Add webhook-level dedup to prevent duplicate job triggers

### DIFF
--- a/azure-function/src/functions/TranscriptWebhook.js
+++ b/azure-function/src/functions/TranscriptWebhook.js
@@ -12,6 +12,43 @@ const { app, output } = require("@azure/functions");
 const LOG_PREFIX = "[TIGER]";
 
 /**
+ * In-memory deduplication cache for webhook notifications.
+ * Prevents duplicate queue messages when Graph sends the same notification twice.
+ * Key: `${meetingId}-${transcriptId}`, Value: timestamp
+ * TTL: 10 minutes
+ *
+ * This works because duplicate Graph notifications typically hit the same
+ * function instance within seconds. The queue-level dedup in ProcessTranscriptQueue
+ * remains as a secondary safety net for cross-instance scenarios.
+ */
+const webhookDedupCache = new Map();
+const DEDUP_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+function isWebhookDuplicate(meetingId, transcriptId) {
+  const key = `${meetingId}-${transcriptId}`;
+  const cachedTime = webhookDedupCache.get(key);
+  if (cachedTime && Date.now() - cachedTime < DEDUP_TTL_MS) {
+    return true;
+  }
+  return false;
+}
+
+function markWebhookProcessed(meetingId, transcriptId) {
+  const key = `${meetingId}-${transcriptId}`;
+  webhookDedupCache.set(key, Date.now());
+
+  // Cleanup old entries to prevent memory leak
+  if (webhookDedupCache.size > 1000) {
+    const now = Date.now();
+    for (const [k, v] of webhookDedupCache) {
+      if (now - v > DEDUP_TTL_MS) {
+        webhookDedupCache.delete(k);
+      }
+    }
+  }
+}
+
+/**
  * Structured logging helper for consistent log format
  */
 function structuredLog(context, level, message, data = {}) {
@@ -115,6 +152,15 @@ app.http("TranscriptWebhook", {
         skippedCount++;
         continue;
       }
+
+      // Deduplicate at webhook level to prevent duplicate queue messages
+      // Graph may send the same notification multiple times (at-least-once delivery)
+      if (isWebhookDuplicate(meetingId, transcriptId)) {
+        structuredLog(context, "info", "SKIP: Duplicate webhook notification", { meetingId, transcriptId });
+        skippedCount++;
+        continue;
+      }
+      markWebhookProcessed(meetingId, transcriptId);
 
       queueMessages.push({
         userId,


### PR DESCRIPTION
## Summary
- Add in-memory deduplication cache in `TranscriptWebhook.js` to catch duplicate Graph notifications before they reach the queue
- Graph sends at-least-once notifications, which caused two Container App Jobs to trigger for the same meeting on 2026-03-31
- The existing queue-level dedup (`ProcessTranscriptQueue.js`) failed because Azure scaled to a second function instance with an empty in-memory cache
- Webhook-level dedup is more effective because duplicate Graph notifications typically hit the same function instance (fast HTTP handler vs slow LRO in queue handler)

## Test plan
- [x] Tested locally with `func start` — first curl returns `queued: 1`, second returns `queued: 0, skipped: 1`
- [x] Deployed to `func-tiger-test` and verified dedup works via curl
- [x] Deployed to `func-tiger-staging`
- [ ] Monitor staging logs for `"SKIP: Duplicate webhook notification"` on next real Graph duplicate

🤖 Generated with [Claude Code](https://claude.com/claude-code)