### PR TITLE
Fix missing saveTranscript call causing ReferenceError

### DIFF
--- a/download-transcript.js
+++ b/download-transcript.js
@@ -993,6 +993,9 @@ async function main() {
       invitees: invitees.map((i) => ({ name: i.derivedName, role: i.role })),
     });
 
+    // Save transcript to file (only reached if meeting passes all filters)
+    const transcriptPath = await saveTranscript(content, filename);
+
     // Output result as JSON to stdout (includes notification info)
     outputResult({
       success: true,


### PR DESCRIPTION
## Summary
- The filter reorder that moved the external participant check before the subject filter accidentally removed the `saveTranscript()` call
- This caused a `ReferenceError: transcriptPath is not defined` crash when processing valid meetings
- Restores the `saveTranscript(content, filename)` call in its correct position after all filters pass

## Test plan
- [x] Triggered a transcript download in the test environment and confirmed it processes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)