### PR TITLE
Local run uses SSW Tiger dashboard domain (#76)

### DIFF
--- a/.claude/skills/deploy-dashboard/SKILL.md
+++ b/.claude/skills/deploy-dashboard/SKILL.md
@@ -1,35 +1,31 @@
 ---
 name: deploy-dashboard
-description: Deploy a meeting dashboard to Azure Blob Storage (dashboards.sswtiger.com) for public sharing. Use when the user wants to deploy, publish, share, or host a dashboard online.
+description: Deploy a meeting dashboard to Azure Blob Storage (dashboards.sswtiger.com) and persist to Cosmos DB. Use when the user wants to deploy, publish, share, or host a dashboard online.
 allowed-tools: Bash
 ---
 
 # Deploy Dashboard to Azure Blob Storage
 
-Deploy a meeting dashboard to Azure Blob Storage, served via dashboards.sswtiger.com.
+Deploy a locally-generated meeting dashboard to Azure Blob Storage (served via dashboards.sswtiger.com) and save meeting data to Cosmos DB.
 
 ## Instructions
 
-1. Verify the dashboard exists at `projects/{project}/{meeting-id}/dashboard/index.html`
+1. Determine the `<project-name>` and `<meeting-id>` from the user's request or the current working context
+2. Verify the dashboard exists at `projects/{project}/{meeting-id}/dashboard/index.html`
    - If it doesn't exist, generate it first using the generate-dashboard skill
-2. Login with Managed Identity (in Azure) or Azure CLI (locally):
+3. Run the deploy command:
    ```bash
-   # Azure Container App (uses managed identity)
-   az login --identity --username $AZURE_CLIENT_ID
-
-   # Local development (use interactive login)
-   az login
-   ```
-3. Upload the dashboard directory to blob storage:
-   ```bash
-   az storage blob upload-batch \
-     --source projects/{project}/{meeting-id}/dashboard \
-     --destination '$web/{project}/{meeting-id}' \
-     --account-name $DASHBOARD_STORAGE_ACCOUNT \
-     --auth-mode login \
-     --overwrite
+   node processor/deploy-local.js <project-name> <meeting-id>
    ```
 4. Report the deployed URL back to the user
+
+## What It Does
+
+The script (`processor/deploy-local.js`) reuses the same `deployer.js` as the Azure pipeline:
+
+1. Uploads dashboard files to Azure Blob Storage
+2. Persists meeting metadata + consolidated analysis to Cosmos DB (if `COSMOS_ENDPOINT` is set)
+3. Returns the public URL
 
 ## Deployment URL Convention
 
@@ -39,9 +35,9 @@ Example: `https://dashboards.sswtiger.com/yakshaver/2026-01-22-094557`
 
 ## Prerequisites
 
-- Azure CLI must be installed
-- `DASHBOARD_STORAGE_ACCOUNT` environment variable must be set
-- User must have Storage Blob Data Contributor role (or Managed Identity in Azure)
+- Azure CLI installed and logged in (`az login`)
+- `DASHBOARD_STORAGE_ACCOUNT` environment variable set in `.env`
+- `DASHBOARD_BASE_URL` environment variable set in `.env` (optional, falls back to Azure hostname)
 
 ## Output
 

--- a/.claude/skills/process-transcript/SKILL.md
+++ b/.claude/skills/process-transcript/SKILL.md
@@ -13,7 +13,7 @@ Convert a .vtt meeting transcript into a comprehensive, deployed HTML dashboard 
 1. ✅ Orchestrates **5 specialized analysis agents**
 2. ✅ Runs **consolidation** to ensure consistency
 3. ✅ Creates a **multi-tab HTML dashboard** with rich insights
-4. ✅ Deploys to **surge.sh**
+4. ✅ Generates a deployable dashboard (deploy via `deploy-dashboard` skill or `node processor/deploy-local.js`)
 5. ✅ Returns a **public URL**
 
 ## NEVER DO
@@ -22,7 +22,7 @@ Convert a .vtt meeting transcript into a comprehensive, deployed HTML dashboard 
 - ❌ Skip any analysis phase
 - ❌ Skip the consolidation step
 - ❌ Generate a simple single-page summary
-- ❌ Skip the deployment
+- ❌ Deploy the dashboard directly (use the deploy-dashboard skill or deploy-local.js instead)
 
 ## Pipeline Steps
 
@@ -129,16 +129,16 @@ Create `projects/{project}/dashboards/{date}/index.html` using the **consolidate
 - Improvement tracking
 - Trajectory visualizations
 
-### Step 5: Deploy to Azure Blob Storage
-```bash
-az login --identity --username $AZURE_CLIENT_ID
-az storage blob upload-batch \
-  --source projects/{project}/{meeting-id}/dashboard \
-  --destination '$web/{project}/{meeting-id}' \
-  --account-name $DASHBOARD_STORAGE_ACCOUNT \
-  --auth-mode login \
-  --overwrite
-```
+### Step 5: Deploy Dashboard
+
+After generating the dashboard, offer deployment options:
+
+1. **Ask Claude:** "deploy the dashboard" → triggers the `deploy-dashboard` skill
+2. **Run manually:** `node processor/deploy-local.js {project} {meeting-id}`
+
+The deployed URL will be: `https://dashboards.sswtiger.com/{project}/{meeting-id}`
+
+> **Note:** When running under `processor.js` (Azure pipeline), deployment is handled automatically by `deployer.js`. Do NOT deploy from within this skill in that context.
 
 ### Step 6: Report Success
 ```

--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,11 @@ CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-YOUR-TOKEN-HERE
 # Dashboard deployment (Azure Blob Storage)
 # Storage account name for static website hosting
 DASHBOARD_STORAGE_ACCOUNT=your_storage_account_name
+# Custom domain for dashboard URLs (production: dashboards.sswtiger.com)
+DASHBOARD_BASE_URL=dashboards.sswtiger.com
+
+# Cosmos DB (meeting persistence)
+COSMOS_ENDPOINT=https://your-cosmos-account.documents.azure.com:443/
 
 # ------------------------------------------------------------------------------
 # Local Testing (Mock Mode)

--- a/Agents.md
+++ b/Agents.md
@@ -4,7 +4,7 @@
 
 ## What This System Does
 
-When a Microsoft Teams meeting ends, T.I.G.E.R. automatically downloads the transcript, runs 6 AI analysis agents, generates an HTML dashboard, deploys it to surge.sh, and notifies participants — zero human intervention.
+When a Microsoft Teams meeting ends, T.I.G.E.R. automatically downloads the transcript, runs 6 AI analysis agents, generates an HTML dashboard, deploys it to Azure Blob Storage (dashboards.sswtiger.com), and notifies participants — zero human intervention.
 
 ## Architecture at a Glance
 
@@ -26,7 +26,7 @@ TranscriptWebhook.js ──► Storage Queue ──► ProcessTranscriptQueue.js
                                          │   ├─ analytics-generator │
                                          │   ├─ longitudinal-anlzr  │
                                          │   └─ consolidator        │
-                                         │ → dashboard → surge.sh   │
+                                         │ → dashboard → Azure Blob Storage   │
                                          │ send-teams-notification  │
                                          └──────────────────────────┘
                                                     │
@@ -132,7 +132,7 @@ Skills in `.claude/skills/` are user-facing workflows that orchestrate the agent
 | `organize-transcript` | File a `.vtt` into the correct project folder | Changing folder structure conventions |
 | `analyze-meeting` | Extract basic insights (summary, action items) | Changing what basic analysis captures |
 | `generate-dashboard` | Generate HTML from `consolidated.json` | Changing dashboard generation logic |
-| `deploy-dashboard` | Deploy to surge.sh | Changing hosting target |
+| `deploy-dashboard` | Deploy to Azure Blob Storage (dashboards.sswtiger.com) | Changing hosting target |
 | `list-projects` | Show all projects and meeting history | Changing project listing format |
 
 ## Data Flow
@@ -265,7 +265,7 @@ secrets: [{
 |---|---|---|
 | Graph API | Client credentials | `OnlineMeetings.Read.All` + `CallRecords.Read.All` + Application Access Policy |
 | Claude CLI | OAuth or API key | OAuth for production, API key for dev |
-| Surge.sh | Email + token | `SURGE_EMAIL` + `SURGE_TOKEN` |
+| Azure Blob Storage | Storage account + base URL | `DASHBOARD_STORAGE_ACCOUNT` + `DASHBOARD_BASE_URL` |
 | Key Vault | Managed Identity | No credentials in code |
 | Webhook | `clientState` | Random string verified per notification |
 
@@ -309,5 +309,5 @@ ContainerAppConsoleLogs_CL
 | Webhook not triggering | Graph subscription expired (3-day TTL) | Check `RenewSubscription.js` timer is running |
 | Transcript download 403 | Application Access Policy missing | Teams Admin must configure the policy |
 | Claude processing timeout | Meeting too long / agents stuck | Increase Container App Job timeout |
-| Dashboard not deploying | Surge credentials expired | Verify `SURGE_EMAIL` + `SURGE_TOKEN` in Key Vault |
+| Dashboard not deploying | Azure storage auth failed | Verify `DASHBOARD_STORAGE_ACCOUNT` is set and `az login` is authenticated |
 | Notifications not sent | Logic App URL misconfigured | Check `LOGIC_APP_URL` env var |

--- a/README-AUTOMATION.md
+++ b/README-AUTOMATION.md
@@ -13,7 +13,7 @@ When a Microsoft Teams meeting ends, the system automatically:
 1. **Detects** new transcripts via Microsoft Graph webhooks
 2. **Downloads** the transcript content (.vtt format)
 3. **Processes** using Claude AI to generate comprehensive analysis
-4. **Deploys** an HTML dashboard to surge.sh
+4. **Deploys** an HTML dashboard to Azure Blob Storage
 5. **Notifies** meeting participants with the dashboard link
 
 All without human intervention.
@@ -88,8 +88,8 @@ All without human intervention.
 │  │      - longitudinal-analyzer (recurring issues)           │  │
 │  │    • Consolidates outputs (name normalization)            │  │
 │  │    • Generates SSW-branded HTML dashboard                 │  │
-│  │    • Deploys to surge.sh                                  │  │
-│  │    • Outputs: DEPLOYED_URL=https://...surge.sh            │  │
+│  │    • Deploys to Azure Blob Storage                        │  │
+│  │    • Outputs: DEPLOYED_URL=https://dashboards.sswtiger.com/...  │  │
 │  └───────────────────────────────────────────────────────────┘  │
 │                          │                                       │
 │                          ↓                                       │
@@ -158,7 +158,7 @@ All without human intervention.
    - GRAPH_USER_ID, GRAPH_MEETING_ID, GRAPH_TRANSCRIPT_ID
    - GRAPH_CLIENT_ID, GRAPH_CLIENT_SECRET, GRAPH_TENANT_ID
    - ANTHROPIC_API_KEY (from Key Vault reference)
-   - SURGE_EMAIL, SURGE_TOKEN (from Key Vault reference)
+   - DASHBOARD_STORAGE_ACCOUNT, DASHBOARD_BASE_URL
 5. Generate unique execution ID
 6. Trigger Container App Job via Azure SDK:
    - Pass all environment variables
@@ -188,8 +188,8 @@ GRAPH_USER_ID, GRAPH_MEETING_ID, GRAPH_TRANSCRIPT_ID
 # Claude authentication
 ANTHROPIC_API_KEY or CLAUDE_CODE_OAUTH_TOKEN
 
-# Surge.sh deployment
-SURGE_EMAIL, SURGE_TOKEN
+# Azure Blob Storage deployment
+DASHBOARD_STORAGE_ACCOUNT, DASHBOARD_BASE_URL
 
 # Optional: Cancellation support
 CHECK_CANCELLATION_URL (Function App endpoint to check cancel status)
@@ -261,7 +261,7 @@ LOGIC_APP_URL (Logic App HTTP trigger)
    - Must match: YYYY-MM-DD-HHmmss.vtt
    - Extract: meetingId, meetingDate, meetingTime
 3. Validate credentials:
-   - Require: SURGE_EMAIL + SURGE_TOKEN
+   - Require: DASHBOARD_STORAGE_ACCOUNT + DASHBOARD_BASE_URL
    - Check: CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_API_KEY
 4. Create project folder structure:
    projects/{project-name}/{meeting-id}/
@@ -280,7 +280,7 @@ LOGIC_APP_URL (Logic App HTTP trigger)
    - Log progress to stderr
    
 7. Monitor for deployment:
-   - Search stdout for: DEPLOYED_URL=https://...surge.sh
+   - Search stdout for: DEPLOYED_URL=https://dashboards.sswtiger.com/...
    - Extract URL using regex
    - Validate URL format
    
@@ -289,7 +289,7 @@ LOGIC_APP_URL (Logic App HTTP trigger)
    - Any non-zero exit code = failure
    
 9. Output to stdout:
-   DEPLOYED_URL=https://projectname-2026-02-04-143000.surge.sh
+   DEPLOYED_URL=https://dashboards.sswtiger.com/projectname/2026-02-04-143000
 ```
 
 **Claude Processing (Internal)**:
@@ -304,7 +304,7 @@ LOGIC_APP_URL (Logic App HTTP trigger)
 
 7. generate-dashboard:    Merge all outputs → Apply SSW template → Generate HTML
 
-8. deploy-dashboard:      Upload to surge.sh → Output URL
+8. deploy-dashboard:      Upload to Azure Blob Storage → Output URL
 ```
 
 #### 3.4. Send Notification (`send-teams-notification.js`)
@@ -373,10 +373,10 @@ LOGIC_APP_URL (Logic App HTTP trigger)
    - Best for testing/development
    - Get from: https://console.anthropic.com/
 
-### Surge.sh Authentication
-**Required**: Email + Token
-- Get token: `surge token`
-- Store in Key Vault
+### Azure Blob Storage Authentication
+**Required**: Storage account name + Azure CLI auth
+- Authenticate: `az login`
+- Store account name in Key Vault
 
 ### Key Vault Integration
 All secrets stored in Azure Key Vault:
@@ -435,9 +435,9 @@ GRAPH_TENANT_ID=...
 ANTHROPIC_API_KEY=...              # Pay-as-you-go
 CLAUDE_CODE_OAUTH_TOKEN=...        # Subscription
 
-# Surge.sh Deployment
-SURGE_EMAIL=...
-SURGE_TOKEN=...
+# Azure Blob Storage Deployment
+DASHBOARD_STORAGE_ACCOUNT=<storage-account-name>
+DASHBOARD_BASE_URL=dashboards.sswtiger.com
 ```
 
 **Optional**:
@@ -473,7 +473,7 @@ param costCategoryTag = { 'cost-category': 'dev/test' }
 2. App Registration (Graph API permissions)
 3. GitHub repository (for CI/CD)
 4. Claude API access (API key or OAuth)
-5. Surge.sh account
+5. Azure Storage account for dashboards
 
 ### Initial Setup
 
@@ -498,7 +498,7 @@ az keyvault secret set --vault-name kv-tiger-staging \
   --name AnthropicApiKey --value "sk-ant-..."
   
 az keyvault secret set --vault-name kv-tiger-staging \
-  --name SurgeToken --value "..."
+  --name DashboardStorageAccount --value "..."
 ```
 
 #### 4. Create Graph Subscription
@@ -544,7 +544,7 @@ docker-compose run --rm meeting-processor \
 
 # 4. Verify output
 # - Dashboard generated in projects/test-project/
-# - Deployed to surge.sh
+# - Deployed to Azure Blob Storage
 ```
 
 ### E2E Testing (Azure)
@@ -566,7 +566,7 @@ curl -X POST https://func-tiger-staging.azurewebsites.net/api/TranscriptWebhook?
 # 5. Wait ~2 minutes for transcript generation
 # 6. Check Function logs for webhook notification
 # 7. Check Container App Job logs for processing
-# 8. Verify dashboard deployed to surge.sh
+# 8. Verify dashboard deployed to Azure Blob Storage
 # 9. Check Teams for notification message
 ```
 
@@ -624,8 +624,8 @@ ContainerAppConsoleLogs_CL
 - **Solution**: Increase timeout or reduce transcript length
 
 **Issue**: Dashboard not deploying
-- **Check**: Surge credentials in Key Vault
-- **Solution**: Verify SURGE_EMAIL and SURGE_TOKEN
+- **Check**: DASHBOARD_STORAGE_ACCOUNT is set
+- **Solution**: Verify DASHBOARD_STORAGE_ACCOUNT and run az login
 
 ---
 
@@ -637,7 +637,7 @@ ContainerAppConsoleLogs_CL
 |-------------|---------|----------|
 | `AnthropicApiKey` | Claude API authentication | https://console.anthropic.com/ |
 | `ClaudeCodeOAuthToken` | Claude subscription (alternative) | `claude auth login` |
-| `SurgeToken` | Surge.sh deployment | `surge token` |
+| `DashboardStorageAccount` | Azure Blob Storage deployment | Azure Portal |
 | `GraphClientSecret` | Graph API app secret | Azure Portal → App Registration |
 | `WebhookClientState` | Webhook validation | Generate random string |
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Transcript (.vtt)
 │  DASHBOARD GENERATION (SSW branded)              │
 └──────────────────────────────────────────────────┘
        ↓
-    Deploy to surge.sh
+    Deploy to Azure Blob Storage (dashboards.sswtiger.com)
 ```
 
 ## 📁 Project Structure
@@ -102,12 +102,32 @@ MeetingSummary/
 ### Prerequisites
 
 - [Claude Code CLI](https://docs.anthropic.com/claude/docs/claude-code)
-- [Node.js](https://nodejs.org/) + surge.sh: `npm install -g surge`
+- [Node.js](https://nodejs.org/)
+- [Azure CLI](https://learn.microsoft.com/en-us/cli/azure/install-azure-cli) (for dashboard deployment)
 
-### Option 1: Interactive Usage (Claude Code CLI)
+### Setup
 
 ```bash
-cd c:\DataCalumSimpson\MeetingSummary
+# 1. Clone and install
+git clone https://github.com/SSWConsulting/SSW.Tiger.git
+cd SSW.Tiger
+npm install
+
+# 2. Configure environment
+cp .env.example .env
+# Edit .env and set:
+#   CLAUDE_CODE_OAUTH_TOKEN (or ANTHROPIC_API_KEY)
+#   DASHBOARD_STORAGE_ACCOUNT=<your-storage-account>
+#   DASHBOARD_BASE_URL=dashboards.sswtiger.com
+#   COSMOS_ENDPOINT=https://<your-cosmos>.documents.azure.com:443/
+
+# 3. Login to Azure (one-time, for dashboard deployment)
+az login
+```
+
+### Option 1: Interactive (Claude Code CLI)
+
+```bash
 claude
 ```
 
@@ -115,33 +135,35 @@ Then talk naturally:
 
 ```
 "Here's the weekly standup for project-alpha" + attach your .vtt file
-```
-
-Or process an existing transcript:
-
-```
 "Process the yakshaver transcript from today"
 ```
 
-### Option 2: Automated Processing (Container)
+Claude generates the dashboard HTML. To deploy it afterwards:
+
+```
+"Deploy the dashboard"           # Tell Claude (uses deploy-dashboard skill)
+```
+
+Or deploy manually from the command line:
+
+```bash
+node processor/deploy-local.js <project-name> <meeting-id>
+```
+
+### Option 2: Automated (Container / Azure)
 
 **Local Development**:
 
 ```bash
-# 1. Configure authentication (.env file)
-cp .env.example .env
-# Edit .env and set ANTHROPIC_API_KEY or CLAUDE_SUBSCRIPTION_TOKEN
-
-# 2. Build container
+# Build and run
 docker-compose build
-
-# 3. Process transcript
 docker-compose run --rm meeting-processor /app/dropzone/meeting.vtt projectname
 ```
 
 **Production (Azure)**:
 
 See [TIGER.md](TIGER.md) for full Azure deployment guide with Key Vault integration.
+The Azure pipeline handles deployment automatically via `processor/index.js` → `deployer.js`.
 
 ## 🔐 Authentication
 
@@ -249,7 +271,7 @@ After processing a transcript, you'll get:
 
 2. **Dashboard** in `projects/{project}/dashboards/{date}/index.html`
 
-3. **Deployment** at `https://{project}-{date}.surge.sh`
+3. **Deployment** at `https://dashboards.sswtiger.com/{project}/{meeting-id}`
 
 ## 🤝 Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,11 @@
       "license": "MIT",
       "dependencies": {
         "@azure/cosmos": "^4.9.2",
-        "@azure/identity": "^4.13.1"
+        "@azure/identity": "^4.13.1",
+        "dotenv": "^17.4.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@azure-rest/core-client": {
@@ -399,6 +400,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.4.2",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
+      "integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/ecdsa-sig-formatter": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "license": "MIT",
   "dependencies": {
     "@azure/cosmos": "^4.9.2",
-    "@azure/identity": "^4.13.1"
+    "@azure/identity": "^4.13.1",
+    "dotenv": "^17.4.2"
   },
   "engines": {
     "node": ">=20.0.0"

--- a/processor/deploy-local.js
+++ b/processor/deploy-local.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+/**
+ * Deploy a locally-generated dashboard to Azure Blob Storage + Cosmos DB.
+ *
+ * Usage:
+ *   node processor/deploy-local.js <project-name> <meeting-id>
+ *
+ * Example:
+ *   node processor/deploy-local.js yakshaver 2026-01-22-094557
+ *
+ * Prerequisites:
+ *   - Azure CLI installed and logged in (az login)
+ *   - DASHBOARD_STORAGE_ACCOUNT set in .env
+ *   - DASHBOARD_BASE_URL set in .env (optional, falls back to Azure hostname)
+ *   - COSMOS_ENDPOINT set in .env
+ */
+
+require("dotenv").config({ path: require("path").join(__dirname, "..", ".env") });
+const path = require("path");
+const { log } = require("../lib/logger");
+const { checkOutputExists, deployDashboard, persistToCosmos } = require("./deployer");
+
+const ROOT_DIR = path.join(__dirname, "..");
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  if (args.length < 2) {
+    console.error("Usage: node processor/deploy-local.js <project-name> <meeting-id>");
+    console.error("Example: node processor/deploy-local.js yakshaver 2026-01-22-094557");
+    process.exit(1);
+  }
+
+  const [projectName, meetingId] = args;
+  const meetingPath = path.join(ROOT_DIR, "projects", projectName, meetingId);
+
+  // Find the dashboard HTML
+  const dashboardPath = await checkOutputExists({
+    meetingPath,
+    outputDir: path.join(ROOT_DIR, "output"),
+    projectName,
+    meetingId,
+  });
+
+  // Deploy to Azure Blob Storage
+  const { deployedUrl, dashboardPath: storagePath } = await deployDashboard({
+    dashboardPath,
+    projectName,
+    meetingId,
+  });
+
+  console.log(`Deployed: ${deployedUrl}`);
+
+  // Persist to Cosmos DB
+  const meetingDate = meetingId.substring(0, 10);
+  await persistToCosmos({
+    projectName,
+    meetingId,
+    meetingDate,
+    dashboardPath: storagePath,
+    meetingPath,
+  });
+  console.log("Saved to Cosmos DB");
+}
+
+main().catch((err) => {
+  console.error(`Deploy failed: ${err.message}`);
+  process.exit(1);
+});

--- a/processor/deploy-local.js
+++ b/processor/deploy-local.js
@@ -18,7 +18,6 @@
 
 require("dotenv").config({ path: require("path").join(__dirname, "..", ".env") });
 const path = require("path");
-const { log } = require("../lib/logger");
 const { checkOutputExists, deployDashboard, persistToCosmos } = require("./deployer");
 
 const ROOT_DIR = path.join(__dirname, "..");

--- a/processor/deployer.js
+++ b/processor/deployer.js
@@ -65,6 +65,7 @@ async function deployDashboard({ dashboardPath, projectName, meetingId }) {
   });
 
   const { execFileSync } = require("child_process");
+  const isWindows = process.platform === "win32";
   const azureClientId = process.env.AZURE_CLIENT_ID;
 
   // Login with managed identity
@@ -74,6 +75,7 @@ async function deployDashboard({ dashboardPath, projectName, meetingId }) {
       execFileSync("az", ["login", "--identity", "--client-id", azureClientId], {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "pipe"],
+        shell: isWindows,
       });
     } catch (err) {
       log("error", "az login --identity failed", { stderr: err.stderr });
@@ -92,7 +94,7 @@ async function deployDashboard({ dashboardPath, projectName, meetingId }) {
       "--account-name", storageAccount,
       "--auth-mode", "login",
       "--overwrite",
-    ], { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"] });
+    ], { encoding: "utf-8", stdio: ["pipe", "pipe", "pipe"], shell: isWindows });
   } catch (err) {
     log("error", "Blob upload failed", { stderr: err.stderr });
     throw err;
@@ -107,7 +109,7 @@ async function deployDashboard({ dashboardPath, projectName, meetingId }) {
         "--name", storageAccount,
         "--query", "primaryEndpoints.web",
         "-o", "tsv",
-      ], { encoding: "utf-8" }).trim().replace(/^https?:\/\//, "").replace(/\/$/, "");
+      ], { encoding: "utf-8", shell: isWindows }).trim().replace(/^https?:\/\//, "").replace(/\/$/, "");
     } catch {
       host = `${storageAccount}.z8.web.core.windows.net`;
       log("warn", "Could not query storage account, using fallback hostname", { host });

--- a/processor/deployer.js
+++ b/processor/deployer.js
@@ -1,3 +1,17 @@
+/**
+ * Dashboard Deployment (Programmatic)
+ *
+ * Deployment is handled by code (not by Claude) for reliability:
+ * - Deterministic: same code, same result, every time
+ * - Fast: direct Node.js, no LLM round-trip
+ * - Atomic: blob upload + Cosmos DB persist in one sequence
+ * - Observable: structured JSON logs, clear errors, exit codes
+ *
+ * Azure pipeline:  processor/index.js → deployer.js (automatic)
+ * Local scripted:  processor/deploy-local.js → deployer.js (one command)
+ * Local interactive: deploy-dashboard skill → deploy-local.js → deployer.js
+ */
+
 const fs = require("fs").promises;
 const path = require("path");
 const { log } = require("../lib/logger");


### PR DESCRIPTION
## Summary
- Add `deploy-local.js` script for one-command local deployment: `node processor/deploy-local.js <project> <meeting-id>`
- Fix `deployer.js` Windows compatibility (`az.cmd` resolution via `shell: isWindows`)
- Update `deploy-dashboard` skill to use `deploy-local.js` (single source of truth with Azure pipeline)
- Replace all Surge.sh references with Azure Blob Storage (`dashboards.sswtiger.com`) across docs and skills
- Add `dotenv` dependency for local `.env` loading
- Add `DASHBOARD_BASE_URL` and `COSMOS_ENDPOINT` to `.env.example`

### Why deployment is programmatic (not via Claude prompt)

| Environment | Deploy method | Path |
|---|---|---|
| Azure pipeline | Automatic | `processor/index.js` → `deployer.js` |
| Local (scripted) | One command | `deploy-local.js` → `deployer.js` |
| Local (interactive) | Ask Claude | `deploy-dashboard` skill → `deploy-local.js` → `deployer.js` |

## Test plan
- [x] Tested `node processor/deploy-local.js test-project 2026-01-21` locally — deploys to Azure Blob Storage successfully
- [x] Tested asking Claude to deploy via the `deploy-dashboard` skill — works
- [x] Tested in test environment
- [x] Verify Azure pipeline still works (no changes to `CLAUDE.md` or `infra/`)
- [x] Verify `grep -ri "surge" --include="*.js" --include="*.sh" --include="*.yml" --include="*.json"` returns no results

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)