### PR TITLE
Fix Cosmos DB illegal character error in meeting IDs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -140,7 +140,8 @@ run_pipeline() {
 
     # Extract values from download result
     TRANSCRIPT_PATH=$(echo "$DOWNLOAD_RESULT" | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin').toString()).transcriptPath")
-    PROJECT_NAME=$(echo "$DOWNLOAD_RESULT" | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin').toString()).projectName")
+    PROJECT_SLUG=$(echo "$DOWNLOAD_RESULT" | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin').toString()).projectName")
+    PROJECT_NAME=$(echo "$DOWNLOAD_RESULT" | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin').toString()).displayName")
     MEETING_SUBJECT=$(echo "$DOWNLOAD_RESULT" | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin').toString()).meetingSubject")
     PARTICIPANTS_JSON=$(echo "$DOWNLOAD_RESULT" | node -pe "JSON.stringify(JSON.parse(require('fs').readFileSync('/dev/stdin').toString()).participants || [])")
     MEETING_DURATION=$(echo "$DOWNLOAD_RESULT" | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin').toString()).meetingDuration || ''")
@@ -171,7 +172,7 @@ run_pipeline() {
     set +e
     # stderr flows through for real-time display
     # stdout (only DEPLOYED_URL) captured to variable
-    PROCESSOR_STDOUT=$(node processor/index.js "$TRANSCRIPT_PATH" "$PROJECT_NAME")
+    PROCESSOR_STDOUT=$(node processor/index.js "$TRANSCRIPT_PATH" "$PROJECT_SLUG")
     PROCESSOR_EXIT_CODE=$?
     set -e
 

--- a/lib/cosmosClient.js
+++ b/lib/cosmosClient.js
@@ -23,6 +23,8 @@ if (!globalThis.crypto) {
 const { CosmosClient } = require("@azure/cosmos");
 const { DefaultAzureCredential } = require("@azure/identity");
 
+const { sanitizeId } = require("./sanitize");
+
 const DB_NAME = process.env.COSMOS_DATABASE || "tiger";
 const CONTAINER_NAME = process.env.COSMOS_CONTAINER || "meetings";
 
@@ -86,9 +88,12 @@ async function upsertMeeting({
 
   const container = getContainer();
 
+  const sanitizedProject = sanitizeId(projectName) || "general";
+  const sanitizedMeetingId = sanitizeId(meetingId);
+
   const document = {
-    id: `${projectName}-${meetingId}`,
-    projectName,
+    id: `${sanitizedProject}-${sanitizedMeetingId}`,
+    projectName: sanitizedProject,
     meetingId,
     meetingDate,
     dashboardPath,
@@ -123,8 +128,9 @@ async function queryMeetings({
     ? "c.id, c.projectName, c.meetingId, c.meetingDate, c.dashboardPath, c.metadata, c.updatedAt"
     : "*";
 
+  const sanitizedProject = sanitizeId(projectName) || "general";
   let query = `SELECT ${selectFields} FROM c WHERE c.projectName = @projectName`;
-  const parameters = [{ name: "@projectName", value: projectName }];
+  const parameters = [{ name: "@projectName", value: sanitizedProject }];
 
   if (startDate) {
     query += " AND c.meetingDate >= @startDate";
@@ -153,11 +159,12 @@ async function queryMeetings({
  */
 async function getMeeting(projectName, meetingId) {
   const container = getContainer();
-  const id = `${projectName}-${meetingId}`;
+  const sanitizedProject = sanitizeId(projectName) || "general";
+  const id = `${sanitizedProject}-${sanitizeId(meetingId)}`;
 
   try {
     const { resource } = await container
-      .item(id, projectName)
+      .item(id, sanitizedProject)
       .read();
     return resource;
   } catch (err) {

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,0 +1,15 @@
+/**
+ * Sanitize a string for use in Cosmos DB document IDs and URL paths.
+ * Strips emojis, special characters, and anything not alphanumeric, hyphen, or dot.
+ * Cosmos DB IDs cannot contain: \, /, #, ?, or characters with code > 255.
+ */
+function sanitizeId(value) {
+  return value
+    .toLowerCase()
+    .replace(/[\s/\\]+/g, "-")    // spaces, slashes to hyphens
+    .replace(/[^a-z0-9.-]/g, "")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-|-$/g, "");
+}
+
+module.exports = { sanitizeId };

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,15 +1,16 @@
 /**
  * Sanitize a string for use in Cosmos DB document IDs and URL paths.
- * Strips emojis, special characters, and anything not alphanumeric, hyphen, or dot.
- * Cosmos DB IDs cannot contain: \, /, #, ?, or characters with code > 255.
+ * Output contains only [a-z0-9-]. All other characters are converted
+ * to hyphens (spaces, dots, slashes) or stripped (emojis, symbols).
  */
 function sanitizeId(value) {
-  return value
+  if (value == null) return "";
+  return String(value)
     .toLowerCase()
-    .replace(/[\s/\\]+/g, "-")    // spaces, slashes to hyphens
-    .replace(/[^a-z0-9.-]/g, "")
-    .replace(/-{2,}/g, "-")
-    .replace(/^-|-$/g, "");
+    .replace(/[\s./\\]+/g, "-")   // spaces, dots, slashes to hyphens
+    .replace(/[^a-z0-9-]/g, "")   // strip everything else
+    .replace(/-{2,}/g, "-")       // collapse consecutive hyphens
+    .replace(/^-|-$/g, "");       // trim leading/trailing hyphens
 }
 
 module.exports = { sanitizeId };

--- a/lib/sanitize.test.js
+++ b/lib/sanitize.test.js
@@ -25,8 +25,12 @@ describe("sanitizeId", () => {
     assert.equal(sanitizeId("--hello--"), "hello");
   });
 
-  it("preserves dots and digits", () => {
-    assert.equal(sanitizeId("SSW.Rewards"), "ssw.rewards");
+  it("converts dots to hyphens", () => {
+    assert.equal(sanitizeId("SSW.Rewards"), "ssw-rewards");
+    assert.equal(sanitizeId("a.b.c"), "a-b-c");
+  });
+
+  it("preserves digits and hyphens", () => {
     assert.equal(sanitizeId("2026-01-22-094557"), "2026-01-22-094557");
   });
 
@@ -36,6 +40,11 @@ describe("sanitizeId", () => {
 
   it("returns empty string for all-emoji input", () => {
     assert.equal(sanitizeId("🎉🎊🎈"), "");
+  });
+
+  it("handles null and undefined without crashing", () => {
+    assert.equal(sanitizeId(null), "");
+    assert.equal(sanitizeId(undefined), "");
   });
 });
 
@@ -88,7 +97,7 @@ describe("parseSubject — projectSlug is safe for Cosmos DB / URLs", () => {
 
   it("preserves dots", () => {
     const r = parseSubject("SSW.Rewards: Weekly Sync");
-    assert.equal(r.projectSlug, "ssw.rewards");
+    assert.equal(r.projectSlug, "ssw-rewards");
   });
 
   it("lowercases normal names", () => {

--- a/lib/sanitize.test.js
+++ b/lib/sanitize.test.js
@@ -1,0 +1,113 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const { sanitizeId } = require("./sanitize");
+const { parseSubject } = require("../processor/downloadTranscript");
+
+describe("sanitizeId", () => {
+  it("strips emojis", () => {
+    assert.equal(sanitizeId("tinacms 🚀"), "tinacms");
+  });
+
+  it("strips Cosmos DB illegal characters (\\, /, #, ?)", () => {
+    assert.equal(sanitizeId("my/project#1?v2\\test"), "my-project1v2-test");
+  });
+
+  it("converts spaces and slashes to hyphens", () => {
+    assert.equal(sanitizeId("hello world"), "hello-world");
+    assert.equal(sanitizeId("TinaCloud/TinaCMS"), "tinacloud-tinacms");
+  });
+
+  it("collapses consecutive hyphens", () => {
+    assert.equal(sanitizeId("a - - b"), "a-b");
+  });
+
+  it("trims leading and trailing hyphens", () => {
+    assert.equal(sanitizeId("--hello--"), "hello");
+  });
+
+  it("preserves dots and digits", () => {
+    assert.equal(sanitizeId("SSW.Rewards"), "ssw.rewards");
+    assert.equal(sanitizeId("2026-01-22-094557"), "2026-01-22-094557");
+  });
+
+  it("lowercases input", () => {
+    assert.equal(sanitizeId("TinaCMS"), "tinacms");
+  });
+
+  it("returns empty string for all-emoji input", () => {
+    assert.equal(sanitizeId("🎉🎊🎈"), "");
+  });
+});
+
+describe("parseSubject — displayName preserves original", () => {
+  it("preserves slashes and casing", () => {
+    const r = parseSubject("TinaCloud/TinaCMS - Sprint Review, Retro and Planning");
+    assert.equal(r.displayName, "TinaCloud/TinaCMS");
+    assert.equal(r.title, "Sprint Review, Retro and Planning");
+  });
+
+  it("preserves emojis", () => {
+    const r = parseSubject("TinaCMS 🚀 - Sprint Review");
+    assert.equal(r.displayName, "TinaCMS 🚀");
+  });
+
+  it("preserves dots", () => {
+    const r = parseSubject("SSW.Rewards: Weekly Sync");
+    assert.equal(r.displayName, "SSW.Rewards");
+  });
+
+  it("preserves bracket format casing", () => {
+    const r = parseSubject("[YakShaver] Sprint Review");
+    assert.equal(r.displayName, "YakShaver");
+    assert.equal(r.title, "Sprint Review");
+  });
+
+  it("defaults to general for null input", () => {
+    const r = parseSubject(null);
+    assert.equal(r.displayName, "general");
+    assert.equal(r.title, "meeting");
+  });
+
+  it("defaults to general for no separator", () => {
+    const r = parseSubject("Just a plain subject");
+    assert.equal(r.displayName, "general");
+    assert.equal(r.title, "Just a plain subject");
+  });
+});
+
+describe("parseSubject — projectSlug is safe for Cosmos DB / URLs", () => {
+  it("lowercases and converts slashes to hyphens", () => {
+    const r = parseSubject("TinaCloud/TinaCMS - Sprint Review, Retro and Planning");
+    assert.equal(r.projectSlug, "tinacloud-tinacms");
+  });
+
+  it("strips emojis", () => {
+    const r = parseSubject("TinaCMS 🚀 - Sprint Review");
+    assert.equal(r.projectSlug, "tinacms");
+  });
+
+  it("preserves dots", () => {
+    const r = parseSubject("SSW.Rewards: Weekly Sync");
+    assert.equal(r.projectSlug, "ssw.rewards");
+  });
+
+  it("lowercases normal names", () => {
+    const r = parseSubject("[YakShaver] Sprint Review");
+    assert.equal(r.projectSlug, "yakshaver");
+  });
+
+  it("falls back to general for all-emoji project name", () => {
+    const r = parseSubject("🎉🎊🎈 - Party Meeting");
+    assert.equal(r.projectSlug, "general");
+  });
+
+  it("falls back to general for null input", () => {
+    const r = parseSubject(null);
+    assert.equal(r.projectSlug, "general");
+  });
+
+  it("converts spaces to hyphens", () => {
+    const r = parseSubject("Normal Project - Standup");
+    assert.equal(r.projectSlug, "normal-project");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Containerized meeting transcript processor that generates analysis dashboards",
   "main": "processor/index.js",
   "scripts": {
-    "start": "node processor/index.js"
+    "start": "node processor/index.js",
+    "test": "node --test lib/**/*.test.js"
   },
   "keywords": [
     "meeting",

--- a/processor/claudeRunner.js
+++ b/processor/claudeRunner.js
@@ -132,7 +132,7 @@ function extractEventPreview(event) {
  * @param {string} params.outputDir - absolute path to output directory
  * @param {string} params.rootDir - absolute path to project root (for templates, CLAUDE.md)
  */
-async function invokeClaude({ projectName, meetingId, meetingDate, meetingPath, outputDir, rootDir }) {
+async function invokeClaude({ projectName, projectSlug, meetingId, meetingDate, meetingPath, outputDir, rootDir }) {
   await fs.mkdir(outputDir, { recursive: true });
 
   const authConfig = getClaudeAuthMethod();
@@ -142,13 +142,13 @@ async function invokeClaude({ projectName, meetingId, meetingDate, meetingPath, 
 Project: ${projectName}
 Meeting ID: ${meetingId}
 Meeting Date: ${meetingDate}
-Meeting folder: projects/${projectName}/${meetingId}/
-Transcript: projects/${projectName}/${meetingId}/transcript.vtt
-Attendees (meeting invite list - use as suggestion for name resolution): projects/${projectName}/${meetingId}/attendees.json
+Meeting folder: projects/${projectSlug}/${meetingId}/
+Transcript: projects/${projectSlug}/${meetingId}/transcript.vtt
+Attendees (meeting invite list - use as suggestion for name resolution): projects/${projectSlug}/${meetingId}/attendees.json
 Dashboard template: templates/dashboard.html
 
 Follow all steps in CLAUDE.md EXCEPT deployment. Do NOT deploy or upload the dashboard.
-Generate the dashboard HTML to: projects/${projectName}/${meetingId}/dashboard/index.html`;
+Generate the dashboard HTML to: projects/${projectSlug}/${meetingId}/dashboard/index.html`;
 
   return new Promise((resolve, reject) => {
     const args = [

--- a/processor/downloadTranscript.js
+++ b/processor/downloadTranscript.js
@@ -37,6 +37,7 @@
 const fs = require("fs").promises;
 const path = require("path");
 const { log } = require("../lib/logger");
+const { sanitizeId } = require("../lib/sanitize");
 
 // Configuration from environment
 const CONFIG = {
@@ -162,7 +163,8 @@ async function runMockMode() {
   }
 
   // Extract project name and generate filename
-  const projectName = extractProjectName(subject);
+  const { displayName, projectSlug } = parseSubject(subject);
+  const projectName = projectSlug;
   // In mock mode, use the mock date directly
   // Convert to Australian Eastern Time for consistency with real mode
   const mockTranscriptDate = CONFIG.mockMeetingDate
@@ -196,6 +198,7 @@ async function runMockMode() {
     success: true,
     transcriptPath,
     projectName,
+    displayName,
     meetingDate,
     filename,
     meetingSubject: subject,
@@ -635,56 +638,53 @@ async function downloadTranscriptContent(token) {
 }
 
 function parseSubject(subject) {
-  if (!subject) return { projectName: "general", title: "meeting" };
+  if (!subject) return { displayName: "general", projectSlug: "general", title: "meeting" };
 
-  let projectName = "general";
+  let displayName = null;
   let title = subject;
 
   // Format 1: [ProjectName] Meeting Title
   const bracketMatch = subject.match(/^\[([^\]]+)\]\s*(.*)$/);
   if (bracketMatch) {
-    projectName = bracketMatch[1].trim();
+    displayName = bracketMatch[1].trim();
     title = bracketMatch[2].trim() || "meeting";
-    return {
-      projectName: projectName.toLowerCase().replace(/\s+/g, "-"),
-      title,
-    };
   }
 
   // Format 2: ProjectName - Meeting Title (dash separator)
   // Support both hyphen (-), en dash (–), and em dash (—)
-  const dashMatch = subject.match(/^([^-–—]+)\s*[-–—]\s*(.+)$/);
-  if (dashMatch) {
-    const projectPart = dashMatch[1].trim();
-    if (projectPart.length <= 30 && !projectPart.includes(" and ")) {
-      projectName = projectPart;
-      title = dashMatch[2].trim();
-      return {
-        projectName: projectName.toLowerCase().replace(/\s+/g, "-"),
-        title,
-      };
+  if (!displayName) {
+    const dashMatch = subject.match(/^([^-–—]+)\s*[-–—]\s*(.+)$/);
+    if (dashMatch) {
+      const projectPart = dashMatch[1].trim();
+      if (projectPart.length <= 30 && !projectPart.includes(" and ")) {
+        displayName = projectPart;
+        title = dashMatch[2].trim();
+      }
     }
   }
 
   // Format 3: ProjectName: Meeting Title (colon separator)
-  const colonMatch = subject.match(/^([^:]+)\s*:\s*(.+)$/);
-  if (colonMatch) {
-    const projectPart = colonMatch[1].trim();
-    if (projectPart.length <= 30 && !projectPart.includes(" and ")) {
-      projectName = projectPart;
-      title = colonMatch[2].trim();
-      return {
-        projectName: projectName.toLowerCase().replace(/\s+/g, "-"),
-        title,
-      };
+  if (!displayName) {
+    const colonMatch = subject.match(/^([^:]+)\s*:\s*(.+)$/);
+    if (colonMatch) {
+      const projectPart = colonMatch[1].trim();
+      if (projectPart.length <= 30 && !projectPart.includes(" and ")) {
+        displayName = projectPart;
+        title = colonMatch[2].trim();
+      }
     }
   }
 
-  return { projectName: "general", title: subject };
+  const resolvedName = displayName || "general";
+  return {
+    displayName: resolvedName,
+    projectSlug: sanitizeId(resolvedName) || "general",
+    title,
+  };
 }
 
 function extractProjectName(subject) {
-  return parseSubject(subject).projectName;
+  return parseSubject(subject).projectSlug;
 }
 
 function generateFilename(meeting, transcriptDate) {
@@ -970,7 +970,8 @@ async function main() {
 
     // Extract project name and generate filename using transcript date
     // Convert to Australian Eastern Time for correct local date
-    const projectName = extractProjectName(subject);
+    const { displayName, projectSlug } = parseSubject(subject);
+    const projectName = projectSlug;
     const meetingDate = convertToAustralianDate(transcriptDate);
     const filename = generateFilename(meeting, transcriptDate);
 
@@ -992,6 +993,7 @@ async function main() {
       success: true,
       transcriptPath,
       projectName,
+      displayName,
       meetingDate,
       filename,
       meetingSubject: subject,

--- a/processor/index.js
+++ b/processor/index.js
@@ -24,7 +24,7 @@ const { checkOutputExists, copyToOutputDirectory, deployDashboard, persistToCosm
 const ROOT_DIR = path.join(__dirname, "..");
 const OUTPUT_DIR = process.env.OUTPUT_DIR || path.join(ROOT_DIR, "output");
 
-async function processTranscript(transcriptPath, projectName) {
+async function processTranscript(transcriptPath, projectSlug) {
   // Validate credentials first (fail fast)
   validateCredentials();
 
@@ -38,7 +38,9 @@ async function processTranscript(transcriptPath, projectName) {
   // Parse meeting info from filename
   const resolvedPath = path.resolve(transcriptPath);
   const { meetingId, meetingDate, meetingTime } = validateTranscriptFilename(resolvedPath);
-  const projectPath = path.join(ROOT_DIR, "projects", projectName);
+  // Display name for Claude prompt / notifications (from env, set by entrypoint.sh)
+  const displayName = process.env.PROJECT_NAME || projectSlug;
+  const projectPath = path.join(ROOT_DIR, "projects", projectSlug);
   const meetingPath = path.join(projectPath, meetingId);
 
   log("debug", "Initialized", { meetingId, meetingDate, meetingTime });
@@ -46,9 +48,10 @@ async function processTranscript(transcriptPath, projectName) {
   // Setup project structure
   await setupProjectStructure({ meetingPath, transcriptPath: resolvedPath });
 
-  // Invoke Claude Code CLI
+  // Invoke Claude Code CLI (uses display name for human-readable prompt)
   await invokeClaude({
-    projectName,
+    projectName: displayName,
+    projectSlug,
     meetingId,
     meetingDate,
     meetingPath,
@@ -60,14 +63,14 @@ async function processTranscript(transcriptPath, projectName) {
   const canonicalPath = await checkOutputExists({
     meetingPath,
     outputDir: OUTPUT_DIR,
-    projectName,
+    projectName: projectSlug,
     meetingId,
   });
 
   // Deploy to Azure Blob Storage
   const { deployedUrl, dashboardPath: storagePath } = await deployDashboard({
     dashboardPath: canonicalPath,
-    projectName,
+    projectName: projectSlug,
     meetingId,
   });
 
@@ -75,7 +78,7 @@ async function processTranscript(transcriptPath, projectName) {
   if (process.env.COSMOS_ENDPOINT) {
     try {
       await persistToCosmos({
-        projectName,
+        projectName: projectSlug,
         meetingId,
         meetingDate,
         dashboardPath: storagePath,
@@ -94,7 +97,7 @@ async function processTranscript(transcriptPath, projectName) {
   const outputCopyPath = await copyToOutputDirectory({
     sourcePath: canonicalPath,
     outputDir: OUTPUT_DIR,
-    projectName,
+    projectName: projectSlug,
     meetingId,
   });
 


### PR DESCRIPTION
## Summary
- Fixes #82 — meeting subjects with emojis, `/`, `.`, `#`, `?` etc. caused Cosmos DB persistence to fail with "Id contains illegal chars"
- `parseSubject()` now returns `{ displayName, projectSlug, title }` — display name preserves original for UI (e.g. "TinaCloud/TinaCMS"), slug is sanitized for machine use (e.g. "tinacloud-tinacms")
- Shared `sanitizeId()` utility (`lib/sanitize.js`) produces slugs containing only `[a-z0-9-]`
- `cosmosClient.js` retains defensive sanitization as a shared library
- 23 unit tests covering sanitization and subject parsing

## Test plan
- [x] Build Docker image from this branch and deploy to test environment
- [x] Create a Teams meeting with special characters in subject (e.g. "TinaCloud/TinaCMS 🚀 - Test Sprint")
- [x] Verify dashboard generates and deploys successfully
- [x] Verify Cosmos DB persistence succeeds (no "illegal chars" error)
- [x] Verify Teams notification shows original display name (not the slug)
- [x] Run `npm test` — 23/23 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)