### PR TITLE
Resolve SSW People profile slug by last name when nicknames don't match

### DIFF
--- a/.claude/agents/consolidator.md
+++ b/.claude/agents/consolidator.md
@@ -30,6 +30,7 @@ This is non-negotiable. Create a canonical name mapping:
 - **Real names over roles** - "Alice" not "Product Owner"
 - **Consistent format** - Pick one and use it everywhere
 - **Handle unknowns** - "Participant 3" for unidentified speakers, with note
+- **Carry through `sswProfileSlug`** - For each canonical participant, copy the resolved SSW.People.Profiles folder slug from `attendees.json` (`invitees[].sswProfileSlug` for invite-list members, `vttInfo.taggedSpeakerSlugs[<name>]` for VTT-tagged speakers). If the resolver returned `null`, propagate `null` — it means "ambiguous, render initials" and must not be replaced with a guess.
 
 #### Mapping Table
 ```json
@@ -40,7 +41,8 @@ This is non-negotiable. Create a canonical name mapping:
       "displayName": "Alice",
       "aliases": ["Alice", "Product Owner", "PO", "the facilitator", "the person running the meeting"],
       "role": "Product Owner",
-      "isIdentified": true
+      "isIdentified": true,
+      "sswProfileSlug": "Alice-Smith"
     },
     {
       "canonical": "Participant 3",

--- a/.claude/agents/people-analyzer.md
+++ b/.claude/agents/people-analyzer.md
@@ -251,8 +251,10 @@ For each participant, provide:
 ## Boardroom / Shared Device Handling
 
 If an `attendees.json` file is available, read it for context. It contains:
-- `invitees[]` — names derived from the meeting invite list (UPNs). Use as a **suggestion** to resolve misspelled names from transcript text.
-- `vttInfo` — whether the VTT has `<v>` speaker tags and which speakers are tagged.
+- `invitees[]` — names derived from the meeting invite list (UPNs). Use as a **suggestion** to resolve misspelled names from transcript text. Each invitee may include an `sswProfileSlug` field (the pre-resolved SSW.People.Profiles folder name).
+- `vttInfo` — whether the VTT has `<v>` speaker tags and which speakers are tagged. May include `vttInfo.taggedSpeakerSlugs`, a map of tagged speaker name → resolved SSW profile slug.
+
+When emitting participants, **carry the `sswProfileSlug` value through to your output** so downstream dashboard generation uses the correct folder (e.g. "Tom Iwainski" → `Thomas-Iwainski`). If `sswProfileSlug` is `null`, propagate `null` — it signals "ambiguous, render initials" and must not be replaced with a guess.
 
 **Resolution priority:**
 1. **`<v>` tags are authoritative** — always use the tagged name, even if the person is not on the invite list

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,10 +305,23 @@ Profile photos are stored in the SSW.People.Profiles GitHub repository:
 https://raw.githubusercontent.com/SSWConsulting/SSW.People.Profiles/main/{Person-Name}/Images/{Person-Name}-Profile.jpg
 ```
 
-**Name Conversion Rules:**
+**Resolving `{Person-Name}` (the folder slug):**
+
+The slug is pre-resolved against the SSW.People.Profiles folder list and stored in `attendees.json`. **Always prefer the pre-resolved value over guessing from the display name** — Teams display names may use nicknames (e.g. "Tom Iwainski") that don't match the actual folder ("Thomas-Iwainski").
+
+For each participant card, look up the slug in this order:
+1. **Invitees**: find the invitee in `attendees.json -> invitees[]` whose `derivedName` matches the participant. Use their `sswProfileSlug`.
+2. **VTT-tagged speakers**: look the participant's name up in `attendees.json -> vttInfo.taggedSpeakerSlugs` (a map of speaker name → slug). Use that slug.
+3. **No entry** (e.g. an external guest with no invite + no `<v>` tag): fall back to constructing `{First-Last}` from their name with normal capitalization.
+
+**Slug field semantics:**
+- `sswProfileSlug: "Thomas-Iwainski"` → use that exact slug in the URL
+- `sswProfileSlug: null` → the resolver couldn't disambiguate. **Render the initials placeholder directly** instead of guessing — do NOT construct a URL from the display name in this case (it would either 404 or, worse, point to the wrong person).
+- Field absent → use the construction fallback above
+
+**Manual conversion rules (only when constructing from a name as a fallback):**
 - Convert spaces to hyphens: "Bob Northwind" → "Bob-Northwind"
 - Preserve capitalization: "Adam Cogan" → "Adam-Cogan"
-- Use full name as stored in SSW People
 
 #### Participant Card HTML Structure
 

--- a/lib/sswPeopleResolver.js
+++ b/lib/sswPeopleResolver.js
@@ -1,0 +1,107 @@
+/**
+ * Resolves a participant's display name to an SSW.People.Profiles folder slug.
+ *
+ * Profile folders live at https://github.com/SSWConsulting/SSW.People.Profiles
+ * as `{First-Last}` directories (e.g. `Thomas-Iwainski`). Teams display names
+ * sometimes use nicknames (e.g. "Tom Iwainski") that don't slug-match exactly.
+ *
+ * Resolution rules (in order):
+ *   1. Exact match on first AND last name -> use it
+ *   2. Last name matches AND only one profile has that last name -> use it
+ *   3. Otherwise (multiple last-name matches with no exact first-name hit, or
+ *      no last-name match at all) -> null (caller renders initials)
+ */
+
+const PEOPLE_PROFILES_API_URL =
+  "https://api.github.com/repos/SSWConsulting/SSW.People.Profiles/contents/";
+
+let _cachedSlugs = null;
+
+async function fetchSswProfileSlugs() {
+  if (_cachedSlugs) return _cachedSlugs;
+
+  const headers = { "User-Agent": "ssw-tiger" };
+  if (process.env.GITHUB_TOKEN) {
+    headers["Authorization"] = `Bearer ${process.env.GITHUB_TOKEN}`;
+  }
+
+  const response = await fetch(PEOPLE_PROFILES_API_URL, { headers });
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch SSW.People.Profiles contents: ${response.status} ${response.statusText}`,
+    );
+  }
+  const items = await response.json();
+
+  _cachedSlugs = items
+    .filter((item) => item.type === "dir" && /-/.test(item.name))
+    .map((item) => item.name);
+
+  return _cachedSlugs;
+}
+
+function cleanName(name) {
+  if (!name) return "";
+  return name.replace(/\s*\[[^\]]*\]\s*/g, "").trim();
+}
+
+function splitName(name) {
+  const cleaned = cleanName(name);
+  if (!cleaned) return { firstName: "", lastName: "" };
+  const parts = cleaned.split(/\s+/);
+  if (parts.length === 1) return { firstName: parts[0], lastName: "" };
+  return {
+    firstName: parts.slice(0, -1).join(" "),
+    lastName: parts[parts.length - 1],
+  };
+}
+
+function splitSlug(slug) {
+  const parts = slug.split("-");
+  if (parts.length < 2) return { firstName: parts[0] || "", lastName: "" };
+  return {
+    firstName: parts.slice(0, -1).join(" "),
+    lastName: parts[parts.length - 1],
+  };
+}
+
+function resolveSswProfileSlug(displayName, slugList) {
+  if (!displayName || !Array.isArray(slugList) || slugList.length === 0) {
+    return null;
+  }
+
+  const { firstName, lastName } = splitName(displayName);
+  if (!lastName) return null;
+
+  const lowerFirst = firstName.toLowerCase();
+  const lowerLast = lastName.toLowerCase();
+
+  const candidates = slugList.map((slug) => ({ slug, ...splitSlug(slug) }));
+
+  const exact = candidates.find(
+    (c) =>
+      c.lastName.toLowerCase() === lowerLast &&
+      c.firstName.toLowerCase() === lowerFirst,
+  );
+  if (exact) return exact.slug;
+
+  const lastMatches = candidates.filter(
+    (c) => c.lastName.toLowerCase() === lowerLast,
+  );
+  if (lastMatches.length === 1) return lastMatches[0].slug;
+
+  return null;
+}
+
+function _resetCacheForTests() {
+  _cachedSlugs = null;
+}
+
+module.exports = {
+  fetchSswProfileSlugs,
+  resolveSswProfileSlug,
+  cleanName,
+  splitName,
+  splitSlug,
+  _resetCacheForTests,
+};

--- a/lib/sswPeopleResolver.js
+++ b/lib/sswPeopleResolver.js
@@ -12,30 +12,46 @@
  *      no last-name match at all) -> null (caller renders initials)
  */
 
-const PEOPLE_PROFILES_API_URL =
-  "https://api.github.com/repos/SSWConsulting/SSW.People.Profiles/contents/";
+const PEOPLE_PROFILES_TREE_URL =
+  "https://api.github.com/repos/SSWConsulting/SSW.People.Profiles/git/trees/main";
+
+const CACHE_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
+
+const { log } = require("./logger");
 
 let _cachedSlugs = null;
+let _cachedAt = 0;
 
 async function fetchSswProfileSlugs() {
-  if (_cachedSlugs) return _cachedSlugs;
+  if (_cachedSlugs && Date.now() - _cachedAt < CACHE_TTL_MS) {
+    return _cachedSlugs;
+  }
 
   const headers = { "User-Agent": "ssw-tiger" };
   if (process.env.GITHUB_TOKEN) {
     headers["Authorization"] = `Bearer ${process.env.GITHUB_TOKEN}`;
   }
 
-  const response = await fetch(PEOPLE_PROFILES_API_URL, { headers });
+  const response = await fetch(PEOPLE_PROFILES_TREE_URL, { headers });
   if (!response.ok) {
     throw new Error(
-      `Failed to fetch SSW.People.Profiles contents: ${response.status} ${response.statusText}`,
+      `Failed to fetch SSW.People.Profiles tree: ${response.status} ${response.statusText}`,
     );
   }
-  const items = await response.json();
+  const data = await response.json();
 
-  _cachedSlugs = items
-    .filter((item) => item.type === "dir" && /-/.test(item.name))
-    .map((item) => item.name);
+  if (data.truncated) {
+    log(
+      "warn",
+      "SSW.People.Profiles tree response was truncated by GitHub - new profiles past the cap won't resolve until we move to a recursive/paginated fetch",
+      { treeSha: data.sha },
+    );
+  }
+
+  _cachedSlugs = (data.tree || [])
+    .filter((node) => node.type === "tree" && /-/.test(node.path))
+    .map((node) => node.path);
+  _cachedAt = Date.now();
 
   return _cachedSlugs;
 }
@@ -95,6 +111,7 @@ function resolveSswProfileSlug(displayName, slugList) {
 
 function _resetCacheForTests() {
   _cachedSlugs = null;
+  _cachedAt = 0;
 }
 
 module.exports = {

--- a/lib/sswPeopleResolver.test.js
+++ b/lib/sswPeopleResolver.test.js
@@ -1,0 +1,149 @@
+const { describe, it } = require("node:test");
+const assert = require("node:assert/strict");
+const {
+  resolveSswProfileSlug,
+  cleanName,
+  splitName,
+  splitSlug,
+} = require("./sswPeopleResolver");
+
+const SAMPLE_SLUGS = [
+  "Adam-Cogan",
+  "Thomas-Iwainski",
+  "Daniel-Mackay",
+  "Tiago-Araujo",
+  "John-Smith",
+  "Jane-Smith",
+  "Mary-Jane-Wilson",
+];
+
+describe("cleanName", () => {
+  it("strips bracketed suffixes like [SSW]", () => {
+    assert.equal(cleanName("Tiago Araujo [SSW]"), "Tiago Araujo");
+  });
+
+  it("trims whitespace", () => {
+    assert.equal(cleanName("  Adam Cogan  "), "Adam Cogan");
+  });
+
+  it("handles empty input", () => {
+    assert.equal(cleanName(""), "");
+    assert.equal(cleanName(null), "");
+    assert.equal(cleanName(undefined), "");
+  });
+});
+
+describe("splitName", () => {
+  it("splits a two-part name", () => {
+    assert.deepEqual(splitName("Tom Iwainski"), {
+      firstName: "Tom",
+      lastName: "Iwainski",
+    });
+  });
+
+  it("treats all but the last token as the first name", () => {
+    assert.deepEqual(splitName("Mary Jane Wilson"), {
+      firstName: "Mary Jane",
+      lastName: "Wilson",
+    });
+  });
+
+  it("returns empty lastName for a single token", () => {
+    assert.deepEqual(splitName("Charlie"), {
+      firstName: "Charlie",
+      lastName: "",
+    });
+  });
+});
+
+describe("splitSlug", () => {
+  it("splits a two-part slug", () => {
+    assert.deepEqual(splitSlug("Thomas-Iwainski"), {
+      firstName: "Thomas",
+      lastName: "Iwainski",
+    });
+  });
+
+  it("treats all but the last hyphen segment as the first name", () => {
+    assert.deepEqual(splitSlug("Mary-Jane-Wilson"), {
+      firstName: "Mary Jane",
+      lastName: "Wilson",
+    });
+  });
+});
+
+describe("resolveSswProfileSlug", () => {
+  it("rule 1: exact first+last match returns the slug", () => {
+    assert.equal(
+      resolveSswProfileSlug("Adam Cogan", SAMPLE_SLUGS),
+      "Adam-Cogan",
+    );
+  });
+
+  it("rule 1: case-insensitive exact match", () => {
+    assert.equal(
+      resolveSswProfileSlug("adam cogan", SAMPLE_SLUGS),
+      "Adam-Cogan",
+    );
+  });
+
+  it("rule 2: unique last name resolves nickname (Tom -> Thomas-Iwainski)", () => {
+    assert.equal(
+      resolveSswProfileSlug("Tom Iwainski", SAMPLE_SLUGS),
+      "Thomas-Iwainski",
+    );
+  });
+
+  it("rule 2: unique last name still resolves when first name is exact", () => {
+    assert.equal(
+      resolveSswProfileSlug("Daniel Mackay", SAMPLE_SLUGS),
+      "Daniel-Mackay",
+    );
+  });
+
+  it("rule 3: ambiguous last name with no exact first-name match returns null", () => {
+    assert.equal(
+      resolveSswProfileSlug("Bob Smith", SAMPLE_SLUGS),
+      null,
+    );
+  });
+
+  it("ambiguous last name still wins when first name matches exactly", () => {
+    assert.equal(
+      resolveSswProfileSlug("Jane Smith", SAMPLE_SLUGS),
+      "Jane-Smith",
+    );
+  });
+
+  it("returns null when last name is not in the list", () => {
+    assert.equal(
+      resolveSswProfileSlug("Random Person", SAMPLE_SLUGS),
+      null,
+    );
+  });
+
+  it("strips [SSW] suffix before matching", () => {
+    assert.equal(
+      resolveSswProfileSlug("Tom Iwainski [SSW]", SAMPLE_SLUGS),
+      "Thomas-Iwainski",
+    );
+  });
+
+  it("returns null for single-token names (no last name)", () => {
+    assert.equal(resolveSswProfileSlug("Charlie", SAMPLE_SLUGS), null);
+  });
+
+  it("returns null for empty/missing inputs", () => {
+    assert.equal(resolveSswProfileSlug("", SAMPLE_SLUGS), null);
+    assert.equal(resolveSswProfileSlug(null, SAMPLE_SLUGS), null);
+    assert.equal(resolveSswProfileSlug("Tom Iwainski", []), null);
+    assert.equal(resolveSswProfileSlug("Tom Iwainski", null), null);
+  });
+
+  it("resolves multi-part-first-name slugs (Mary Jane Wilson)", () => {
+    assert.equal(
+      resolveSswProfileSlug("Mary Jane Wilson", SAMPLE_SLUGS),
+      "Mary-Jane-Wilson",
+    );
+  });
+});

--- a/lib/sswPeopleResolver.test.js
+++ b/lib/sswPeopleResolver.test.js
@@ -94,10 +94,15 @@ describe("resolveSswProfileSlug", () => {
     );
   });
 
-  it("rule 2: unique last name still resolves when first name is exact", () => {
+  it("rule 2: resolves when first name is missing entirely (single Adams in list)", () => {
+    // Last-name-only input ("Adams" alone has no last name token, so use a
+    // case where first name differs but last name is unique) - covered by
+    // the Tom -> Thomas-Iwainski test above. This case asserts rule 2 still
+    // fires when the input first name is unrelated but the last name is
+    // unique in the directory.
     assert.equal(
-      resolveSswProfileSlug("Daniel Mackay", SAMPLE_SLUGS),
-      "Daniel-Mackay",
+      resolveSswProfileSlug("Tommy Iwainski", SAMPLE_SLUGS),
+      "Thomas-Iwainski",
     );
   });
 

--- a/processor/projectSetup.js
+++ b/processor/projectSetup.js
@@ -1,6 +1,10 @@
 const fs = require("fs").promises;
 const path = require("path");
 const { log } = require("../lib/logger");
+const {
+  fetchSswProfileSlugs,
+  resolveSswProfileSlug,
+} = require("../lib/sswPeopleResolver");
 
 /**
  * Validate transcript filename matches YYYY-MM-DD-HHmmss.vtt pattern.
@@ -63,10 +67,43 @@ async function setupProjectStructure({ meetingPath, transcriptPath }) {
     if (inviteesJson) {
       const invitees = JSON.parse(inviteesJson);
       const vttInfo = vttInfoJson ? JSON.parse(vttInfoJson) : {};
+
+      let slugList = null;
+      try {
+        slugList = await fetchSswProfileSlugs();
+        log("info", "Fetched SSW.People.Profiles slug list", {
+          slugCount: slugList.length,
+        });
+      } catch (error) {
+        log(
+          "warn",
+          "Failed to fetch SSW.People.Profiles slug list, skipping resolution",
+          { error: error.message },
+        );
+      }
+
+      if (slugList) {
+        for (const invitee of invitees) {
+          invitee.sswProfileSlug = resolveSswProfileSlug(
+            invitee.derivedName,
+            slugList,
+          );
+        }
+        if (Array.isArray(vttInfo.taggedSpeakers)) {
+          vttInfo.taggedSpeakerSlugs = {};
+          for (const speaker of vttInfo.taggedSpeakers) {
+            vttInfo.taggedSpeakerSlugs[speaker] = resolveSswProfileSlug(
+              speaker,
+              slugList,
+            );
+          }
+        }
+      }
+
       const attendeesData = {
         invitees,
         vttInfo,
-        note: "Invitees are derived from the meeting invite list (UPNs). Use as a suggestion for name resolution — speaker <v> tags in the VTT are authoritative and take priority.",
+        note: "Invitees are derived from the meeting invite list (UPNs). Use as a suggestion for name resolution — speaker <v> tags in the VTT are authoritative and take priority. The 'sswProfileSlug' field (when present) is the resolved SSW.People.Profiles folder name; use it to build the profile photo URL. If sswProfileSlug is null, render the initials placeholder instead of guessing a slug from the display name.",
       };
       const attendeesPath = path.join(meetingPath, "attendees.json");
       await fs.writeFile(


### PR DESCRIPTION
## 📝 Summary of Changes

Corresponding Issue: #97 

- Profile photos now resolve correctly when a participant's Teams display name uses a nickname that doesn't match their SSW.People.Profiles folder (e.g. "Tom Iwainski" -> `Thomas-Iwainski`).
- When a last name is genuinely ambiguous across multiple SSW profiles and no first name matches exactly, the card falls back to initials instead of silently picking the wrong photo.

### 🤷‍♂️ Why
Today the agent slugifies the display name straight into the GitHub raw URL, so any nickname (Tom/Thomas, Mike/Michael, Liz/Elizabeth, etc.) 404s and shows initials. Adding a deterministic last-name lookup against the public SSW.People.Profiles folder list fixes the common case without introducing AI judgement, and keeps the bad-photo failure mode (ambiguous last names) explicit rather than accidental.

### 🧪 Test plan
- [x] `npm test` passes (42 tests, +19 new for the resolver)
- [x] Unit tests cover: exact match, unique-last-name nickname (Tom -> Thomas-Iwainski), ambiguous last name -> null, missing last name, empty inputs, `[SSW]` suffix stripping, multi-part first names
- [x] Re-run a past meeting that previously rendered Tom Iwainski as initials and confirm the dashboard now loads `Thomas-Iwainski`'s photo (use `/api/TriggerProcessing`)
- [x] Confirm `attendees.json` written by the container now contains `sswProfileSlug` per invitee and `vttInfo.taggedSpeakerSlugs`
- [x] Confirm a non-SSW guest still renders cleanly (no slug -> initials fallback unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)