### PR TITLE
Repair corrupted tailwind.config in generated dashboards

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "processor/index.js",
   "scripts": {
     "start": "node processor/index.js",
-    "test": "node --test lib/**/*.test.js"
+    "test": "node --test lib/**/*.test.js processor/**/*.test.js"
   },
   "keywords": [
     "meeting",

--- a/processor/dashboardValidator.js
+++ b/processor/dashboardValidator.js
@@ -1,0 +1,150 @@
+/**
+ * Dashboard Validator & Repair
+ *
+ * Guard against LLM-generated syntax errors in the dashboard's inline
+ * <script> blocks. The Tailwind config block is the highest-blast-radius
+ * target: a single typo there throws a SyntaxError, the entire
+ * `tailwind.config = {...}` assignment never runs, and every utility
+ * built on the custom palette (`ssw-red`, `ssw-charcoal`, `ssw-gray`)
+ * silently produces no CSS — leaving the dashboard mostly black-and-white
+ * with invisible text.
+ *
+ * After the model writes the dashboard HTML, this module:
+ *   1. Extracts every inline <script> block.
+ *   2. Parses each via `new Function(body)` to surface SyntaxErrors
+ *      without executing the code.
+ *   3. If any block fails to parse, replaces the corrupted
+ *      `tailwind.config` block with the canonical version from
+ *      templates/dashboard.html.
+ *   4. Re-validates after repair and writes the fixed file.
+ */
+
+const fs = require("fs").promises;
+const { log } = require("../lib/logger");
+
+const SCRIPT_BLOCK_REGEX = /<script(\s[^>]*)?>([\s\S]*?)<\/script>/g;
+const TAILWIND_CONFIG_MARKER = /tailwind\.config\s*=\s*\{/;
+
+/**
+ * Find inline <script> blocks (those without a `src` attribute) and
+ * return their bodies.
+ */
+function extractInlineScripts(html) {
+  const blocks = [];
+  for (const match of html.matchAll(SCRIPT_BLOCK_REGEX)) {
+    const attrs = match[1] || "";
+    const body = match[2] || "";
+    if (/\bsrc\s*=/.test(attrs)) continue;
+    if (!body.trim()) continue;
+    blocks.push({ attrs, body, full: match[0], index: match.index });
+  }
+  return blocks;
+}
+
+/**
+ * Find the inline <script> block that assigns to `tailwind.config`.
+ * Returns null if none found.
+ */
+function findTailwindConfigScript(html) {
+  for (const block of extractInlineScripts(html)) {
+    if (TAILWIND_CONFIG_MARKER.test(block.body)) {
+      return block;
+    }
+  }
+  return null;
+}
+
+/**
+ * Try to parse a script body as a function body. Returns the SyntaxError
+ * (or other Error) if parsing fails, otherwise null. `new Function` only
+ * parses the body; it does not execute it, so undefined free variables
+ * (like `tailwind`) do not trigger a runtime error here.
+ */
+function findSyntaxError(body) {
+  try {
+    new Function(body);
+    return null;
+  } catch (err) {
+    return err;
+  }
+}
+
+/**
+ * Validate the dashboard's inline scripts. If any block has a syntax
+ * error, repair by replacing the canonical `tailwind.config` block from
+ * the template (which is the only block known to be a recurring
+ * regeneration target). Writes the file back if repaired.
+ *
+ * @param {string} dashboardPath - absolute path to dashboard HTML
+ * @param {string} templatePath - absolute path to templates/dashboard.html
+ * @returns {Promise<{ok: boolean, repaired: boolean, reason?: string}>}
+ */
+async function validateAndRepairDashboard(dashboardPath, templatePath) {
+  const html = await fs.readFile(dashboardPath, "utf8");
+  const scripts = extractInlineScripts(html);
+
+  const failures = scripts
+    .map((s) => ({ ...s, error: findSyntaxError(s.body) }))
+    .filter((s) => s.error);
+
+  if (failures.length === 0) {
+    log("debug", "Dashboard inline scripts all parse cleanly", {
+      scriptCount: scripts.length,
+    });
+    return { ok: true, repaired: false };
+  }
+
+  log("warn", "Dashboard inline <script> has syntax error(s) - attempting repair", {
+    failureCount: failures.length,
+    firstError: failures[0].error.message,
+  });
+
+  const dashboardTailwindBlock = findTailwindConfigScript(html);
+  if (!dashboardTailwindBlock) {
+    log("warn", "Dashboard has no tailwind.config block to repair");
+    return { ok: false, repaired: false, reason: "no-matching-block-in-dashboard" };
+  }
+
+  const template = await fs.readFile(templatePath, "utf8");
+  const canonicalBlock = findTailwindConfigScript(template);
+  if (!canonicalBlock) {
+    log("warn", "Could not locate canonical tailwind.config block in template - skipping repair");
+    return { ok: false, repaired: false, reason: "template-block-not-found" };
+  }
+
+  const corruptedBlockSyntaxError = findSyntaxError(dashboardTailwindBlock.body);
+  if (!corruptedBlockSyntaxError) {
+    log("warn", "Dashboard tailwind.config block parses cleanly; corruption is elsewhere - cannot auto-repair");
+    return { ok: false, repaired: false, reason: "corruption-outside-tailwind-block" };
+  }
+
+  const repaired =
+    html.slice(0, dashboardTailwindBlock.index) +
+    canonicalBlock.full +
+    html.slice(dashboardTailwindBlock.index + dashboardTailwindBlock.full.length);
+
+  const remainingFailures = extractInlineScripts(repaired)
+    .map((s) => ({ ...s, error: findSyntaxError(s.body) }))
+    .filter((s) => s.error);
+
+  if (remainingFailures.length > 0) {
+    log("warn", "Repair did not eliminate all syntax errors", {
+      remaining: remainingFailures.length,
+      firstError: remainingFailures[0].error.message,
+    });
+    return { ok: false, repaired: false, reason: "repair-incomplete" };
+  }
+
+  await fs.writeFile(dashboardPath, repaired);
+  log("info", "Dashboard tailwind.config block repaired from template", {
+    dashboardPath,
+  });
+  return { ok: true, repaired: true };
+}
+
+module.exports = {
+  validateAndRepairDashboard,
+  extractInlineScripts,
+  findTailwindConfigScript,
+  findSyntaxError,
+};

--- a/processor/dashboardValidator.test.js
+++ b/processor/dashboardValidator.test.js
@@ -1,0 +1,179 @@
+const { describe, it, before, after } = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("fs").promises;
+const path = require("path");
+const os = require("os");
+
+const {
+  validateAndRepairDashboard,
+  extractInlineScripts,
+  findSyntaxError,
+} = require("./dashboardValidator");
+
+const CANONICAL_TAILWIND_BLOCK = `<script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ssw-red': { DEFAULT: '#CC4141' },
+                        'ssw-charcoal': { DEFAULT: '#333333' },
+                        'ssw-gray': { 50: '#FAFAFA' }
+                    },
+                    fontFamily: {
+                        'sans': ['Inter', 'Helvetica Neue', 'Helvetica', 'sans-serif'],
+                    }
+                }
+            }
+        }
+    </script>`;
+
+const CORRUPTED_TAILWIND_BLOCK = `<script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ssw-red': { DEFAULT: '#CC4141' },
+                        'ssw-charcoal': { DEFAULT: '#333333' },
+                        'ssw-gray': { 50: '#FAFAFA' }
+                    },
+                    fontFamily: {
+                        'sans': ['Inter', 'Helvetica Neue', 'Helvetica', sans-serif'],
+                    }
+                }
+            }
+        }
+    </script>`;
+
+function buildHtml(tailwindBlock) {
+  return `<!DOCTYPE html>
+<html><head>
+<script src="https://cdn.tailwindcss.com"></script>
+${tailwindBlock}
+<style>body { font-family: 'Inter'; }</style>
+</head><body>
+<div class="bg-ssw-red text-ssw-charcoal">Hello</div>
+<script>
+  document.querySelector('.profile').addEventListener('click', () => {});
+</script>
+</body></html>`;
+}
+
+describe("extractInlineScripts", () => {
+  it("returns inline script bodies and skips external <script src=...>", () => {
+    const html = `<script src="https://cdn.example.com/x.js"></script><script>var x = 1;</script>`;
+    const scripts = extractInlineScripts(html);
+    assert.equal(scripts.length, 1);
+    assert.match(scripts[0].body, /var x = 1/);
+  });
+
+  it("skips empty inline scripts", () => {
+    const html = `<script>   </script><script>var x = 1;</script>`;
+    const scripts = extractInlineScripts(html);
+    assert.equal(scripts.length, 1);
+  });
+
+  it("captures multiple inline scripts in order", () => {
+    const html = `<script>var a = 1;</script><script>var b = 2;</script>`;
+    const scripts = extractInlineScripts(html);
+    assert.equal(scripts.length, 2);
+    assert.match(scripts[0].body, /var a/);
+    assert.match(scripts[1].body, /var b/);
+  });
+});
+
+describe("findSyntaxError", () => {
+  it("returns null for valid JS", () => {
+    assert.equal(findSyntaxError("var x = 1; x + 2;"), null);
+  });
+
+  it("returns null for valid JS that references undeclared free variables", () => {
+    assert.equal(findSyntaxError("tailwind.config = { theme: {} };"), null);
+  });
+
+  it("returns null for the canonical tailwind.config block body", () => {
+    const body = CANONICAL_TAILWIND_BLOCK.replace(/^<script>|<\/script>$/g, "");
+    assert.equal(findSyntaxError(body), null);
+  });
+
+  it("returns a SyntaxError for the corrupted sans-serif typo", () => {
+    const body = CORRUPTED_TAILWIND_BLOCK.replace(/^<script>|<\/script>$/g, "");
+    const err = findSyntaxError(body);
+    assert.ok(err, "expected a syntax error");
+    assert.equal(err.name, "SyntaxError");
+  });
+
+  it("returns a SyntaxError for unbalanced braces", () => {
+    const err = findSyntaxError("var x = { foo: 1");
+    assert.ok(err);
+    assert.equal(err.name, "SyntaxError");
+  });
+});
+
+describe("validateAndRepairDashboard", () => {
+  let tmpDir;
+
+  before(async () => {
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "tiger-dashboard-test-"));
+  });
+
+  after(async () => {
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("returns ok=true, repaired=false for a clean dashboard", async () => {
+    const dashboardPath = path.join(tmpDir, "clean.html");
+    const templatePath = path.join(tmpDir, "template.html");
+    const cleanHtml = buildHtml(CANONICAL_TAILWIND_BLOCK);
+    await fs.writeFile(dashboardPath, cleanHtml);
+    await fs.writeFile(templatePath, cleanHtml);
+
+    const result = await validateAndRepairDashboard(dashboardPath, templatePath);
+    assert.deepEqual(result, { ok: true, repaired: false });
+
+    const after = await fs.readFile(dashboardPath, "utf8");
+    assert.equal(after, cleanHtml, "clean dashboard must not be rewritten");
+  });
+
+  it("repairs a dashboard with a corrupted tailwind.config block", async () => {
+    const dashboardPath = path.join(tmpDir, "corrupt.html");
+    const templatePath = path.join(tmpDir, "template-corrupt.html");
+    const corruptHtml = buildHtml(CORRUPTED_TAILWIND_BLOCK);
+    const cleanHtml = buildHtml(CANONICAL_TAILWIND_BLOCK);
+    await fs.writeFile(dashboardPath, corruptHtml);
+    await fs.writeFile(templatePath, cleanHtml);
+
+    const result = await validateAndRepairDashboard(dashboardPath, templatePath);
+    assert.equal(result.ok, true);
+    assert.equal(result.repaired, true);
+
+    const after = await fs.readFile(dashboardPath, "utf8");
+    assert.match(after, /'sans-serif'/, "repaired file must contain quoted sans-serif");
+    assert.doesNotMatch(after, /, sans-serif']/, "corruption must be gone");
+
+    const scripts = extractInlineScripts(after);
+    for (const s of scripts) {
+      assert.equal(findSyntaxError(s.body), null, "all scripts must parse after repair");
+    }
+  });
+
+  it("returns ok=false when corruption is outside the tailwind.config block", async () => {
+    const dashboardPath = path.join(tmpDir, "other-error.html");
+    const templatePath = path.join(tmpDir, "template-other.html");
+    const otherCorruption = `<!DOCTYPE html>
+<html><head>
+${CANONICAL_TAILWIND_BLOCK}
+</head><body>
+<script>
+  var broken = { foo: 1
+</script>
+</body></html>`;
+    const cleanHtml = buildHtml(CANONICAL_TAILWIND_BLOCK);
+    await fs.writeFile(dashboardPath, otherCorruption);
+    await fs.writeFile(templatePath, cleanHtml);
+
+    const result = await validateAndRepairDashboard(dashboardPath, templatePath);
+    assert.equal(result.ok, false);
+    assert.equal(result.repaired, false);
+    assert.equal(result.reason, "corruption-outside-tailwind-block");
+  });
+});

--- a/processor/index.js
+++ b/processor/index.js
@@ -20,6 +20,7 @@ const { log } = require("../lib/logger");
 const { validateTranscriptFilename, setupProjectStructure } = require("./projectSetup");
 const { validateCredentials, invokeClaude } = require("./claudeRunner");
 const { checkOutputExists, copyToOutputDirectory, deployDashboard, persistToCosmos } = require("./deployer");
+const { validateAndRepairDashboard } = require("./dashboardValidator");
 
 const ROOT_DIR = path.join(__dirname, "..");
 const OUTPUT_DIR = process.env.OUTPUT_DIR || path.join(ROOT_DIR, "output");
@@ -66,6 +67,18 @@ async function processTranscript(transcriptPath, projectSlug) {
     projectName: projectSlug,
     meetingId,
   });
+
+  // Guard against syntax errors in inline <script> blocks (mainly the
+  // tailwind.config block, which the model has been observed to corrupt
+  // in rare regenerations - see GitHub issue #98).
+  try {
+    await validateAndRepairDashboard(
+      canonicalPath,
+      path.join(ROOT_DIR, "templates", "dashboard.html"),
+    );
+  } catch (err) {
+    log("warn", "Dashboard validation step failed (non-fatal)", { error: err.message });
+  }
 
   // Deploy to Azure Blob Storage
   const { deployedUrl, dashboardPath: storagePath } = await deployDashboard({

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -74,7 +74,7 @@
             font-size: 18px;
         }
         body {
-            font-family: 'Inter', 'Helvetica Neue', 'Helvetica';
+            font-family: 'Inter', 'Helvetica Neue', 'Helvetica', sans-serif;
             font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
         }
         
@@ -501,7 +501,7 @@
             palette: ['#CC4141', '#333333', '#666666', '#E25252', '#888888', '#A33434', '#B0B0B0']
         };
         
-        Chart.defaults.font.family = "'Inter', 'Helvetica Neue', 'Helvetica'";
+        Chart.defaults.font.family = "'Inter', 'Helvetica Neue', 'Helvetica', sans-serif";
         Chart.defaults.color = '#333333';
 
         // Handle profile image load failures - falls back to initials

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -74,7 +74,7 @@
             font-size: 18px;
         }
         body {
-            font-family: 'Inter', 'Helvetica Neue', 'Helvetica', sans-serif;
+            font-family: 'Inter', 'Helvetica Neue', 'Helvetica';
             font-feature-settings: 'cv02', 'cv03', 'cv04', 'cv11';
         }
         
@@ -501,7 +501,7 @@
             palette: ['#CC4141', '#333333', '#666666', '#E25252', '#888888', '#A33434', '#B0B0B0']
         };
         
-        Chart.defaults.font.family = "'Inter', 'Helvetica Neue', 'Helvetica', sans-serif";
+        Chart.defaults.font.family = "'Inter', 'Helvetica Neue', 'Helvetica'";
         Chart.defaults.color = '#333333';
 
         // Handle profile image load failures - falls back to initials


### PR DESCRIPTION
## 📝 Summary of Changes

Corresponding issue: #98
- Generated dashboards with a corrupted `tailwind.config` block (which made the dashboard render mostly black-and-white with invisible text) are now auto-detected and auto-repaired before deployment instead of shipping broken.

### 🤷‍♂️ Why
The dashboard's inline `tailwind.config` script defines the `ssw-red`, `ssw-charcoal`, and `ssw-gray` palettes. In rare regenerations the model emits a JS syntax error in this block (e.g. dropping the leading quote on `'sans-serif'`), the entire script throws on parse, and every utility built on those palettes silently produces no CSS - so brand colours and most text become invisible. The failure rate is low but the user-facing impact when it happens is severe (whole dashboard unreadable).

The fix is a post-processor validation step that runs after Claude writes the dashboard but before deployment:

1. Parse every inline `<script>` block via `new Function(body)` (parse-only, no execution).
2. If any block fails, locate the dashboard's `tailwind.config` block, confirm it is the corrupted one, and replace it with the canonical block from `templates/dashboard.html`.
3. Re-validate after repair; only write the file if all scripts now parse.
4. If validation itself throws, deployment continues with the original file (non-fatal).

### 🧪 Test plan
- [x] Unit tests cover clean dashboard, corrupted-tailwind-block repair, and corruption outside the tailwind block (53 tests pass)
- [x] End-to-end smoke test: validator detects and repairs the actual broken dashboard reported in #98 (zero remaining syntax errors after repair)
- [ ] Reviewer: process a fresh transcript end-to-end and confirm the new validation step logs and that a clean dashboard is unchanged
- [ ] Reviewer: optionally hand-corrupt a generated `index.html` (e.g. break a quote in the tailwind block) and confirm the processor repairs it before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)