### PR TITLE
Remove caption above dashboard screenshot in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@
 
 </div>
 
-SSW.Tiger - see insights from a meeting
-
 ![SSW.Tiger dashboard example](docs/images/tiger-example.png)
 
 ---


### PR DESCRIPTION
## 📝 Summary of Changes

- Removed the "SSW.Tiger - see insights from a meeting" line above the dashboard screenshot in `README.md`

### 🤷‍♂️ Why

The screenshot speaks for itself; the caption was redundant.

### 🧪 Test plan

- [ ] README on GitHub shows the screenshot directly under the intro tagline with no caption above it