### PR TITLE
Fix accidental job cancellation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ AzuriteConfig
 
 # Bicep outputs
 infra/main.json
+
+# AI agent folders
+.agents
+.codex

--- a/azure-function/src/functions/CancelProcessing.js
+++ b/azure-function/src/functions/CancelProcessing.js
@@ -103,6 +103,7 @@ function generateCancelConfirmation(request, details = {}) {
     }
     .title { font-size: 24px; font-weight: 600; margin-bottom: 12px; }
     .message { color: #555; line-height: 1.5; margin-bottom: 24px; }
+    .keep-hint { color: #777; font-size: 14px; margin-bottom: 16px; }
     .details { font-size: 11px; color: #888; margin-top: 24px; overflow-wrap: anywhere; }
     .details strong { color: #777; font-weight: 600; }
     .actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
@@ -123,8 +124,8 @@ function generateCancelConfirmation(request, details = {}) {
   <div class="card">
     <div class="title">Stop analyzing this meeting?</div>
     <div class="message">If you stop, the meeting will not be analyzed and no dashboard will be generated.</div>
+    <div class="keep-hint">To keep it running, close this tab.</div>
     <div class="actions">
-      <a class="secondary" href="javascript:window.close()">Keep Running</a>
       <form method="POST" action="${escapeHtml(request.url)}">
         <button type="submit">Stop Analysis</button>
       </form>
@@ -222,31 +223,13 @@ function createResponse(request, success, message, statusCode, details = {}) {
  *   - subscriptionId: Azure subscription ID
  *
  * This function:
- *   1. Marks the execution as cancelled so the container can exit cleanly
- *   2. If execution tracking is unavailable, falls back to stopping the running job
+ *   1. Validates that the target job execution is still running
+ *   2. Stops the execution through the Container Apps API after explicit confirmation
  */
 
-// In-memory store of cancelled executionIds (for check endpoint)
-// Note: This is per-instance, but cancellation is best-effort
+// Legacy in-memory store for CheckCancellation.
+// Explicit cancellation now stops the Container App Job execution directly.
 const cancelledExecutions = new Set();
-const CANCELLED_TTL_MS = 30 * 60 * 1000; // 30 minutes
-const cancelledTimestamps = new Map();
-
-function markAsCancelled(executionId) {
-  cancelledExecutions.add(executionId);
-  cancelledTimestamps.set(executionId, Date.now());
-
-  // Cleanup old entries
-  if (cancelledExecutions.size > 100) {
-    const now = Date.now();
-    for (const [id, ts] of cancelledTimestamps) {
-      if (now - ts > CANCELLED_TTL_MS) {
-        cancelledExecutions.delete(id);
-        cancelledTimestamps.delete(id);
-      }
-    }
-  }
-}
 
 function isCancelled(executionId) {
   return cancelledExecutions.has(executionId);
@@ -404,11 +387,10 @@ app.http("CancelProcessing", {
     let executionName = mapping?.executionName;
 
     try {
+      const client = getContainerAppsClient(subscriptionIdParam);
+
       // If no mapping found, list running executions and find/stop them
       if (!executionName) {
-        // Get the Container Apps client only for the force-stop fallback.
-        const client = getContainerAppsClient(subscriptionIdParam);
-
         structuredLog(
           context,
           "info",
@@ -473,8 +455,6 @@ app.http("CancelProcessing", {
             previousStatus: targetExecution.status,
           });
           executionName = targetExecution.name;
-          // Mark as cancelled only after the force-stop succeeded
-          markAsCancelled(executionId);
         } catch (stopError) {
           structuredLog(context, "warn", "Could not stop job execution", {
             executionName: targetExecution.name,
@@ -488,20 +468,40 @@ app.http("CancelProcessing", {
           );
         }
       } else {
-        // Found in cache, let the container's cancellation checker stop itself.
+        const snapshot = await getExecutionSnapshot(
+          client,
+          resourceGroup,
+          jobName,
+          executionName,
+        );
+
+        if (
+          !snapshot.targetExecution ||
+          !isRunningStatus(snapshot.targetExecution.status)
+        ) {
+          removeExecutionMapping(executionId);
+          return createResponse(
+            request,
+            false,
+            "No running job executions found. It may have already completed.",
+            404,
+            { executionId, executionName },
+          );
+        }
+
+        await client.jobsExecutions.delete(resourceGroup, jobName, executionName);
         structuredLog(
           context,
           "info",
-          "Marked job execution for cooperative cancellation",
+          "Job execution stopped from cache",
           {
             jobName,
             executionName,
             resourceGroup,
+            previousStatus: snapshot.targetExecution.status,
           },
         );
 
-        // Mark as cancelled only after confirming the cooperative path is valid
-        markAsCancelled(executionId);
         // Remove from mapping cache
         removeExecutionMapping(executionId);
       }

--- a/azure-function/src/functions/CancelProcessing.js
+++ b/azure-function/src/functions/CancelProcessing.js
@@ -67,6 +67,94 @@ function generateHtmlResponse(success, message, details = {}) {
 </html>`;
 }
 
+function escapeHtml(value) {
+  return String(value ?? "")
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+function generateCancelConfirmation(request, details = {}) {
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Confirm Cancel - SSW Tiger</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f5f5f5;
+      color: #333;
+    }
+    .card {
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+      padding: 40px;
+      text-align: center;
+      max-width: 420px;
+    }
+    .title { font-size: 24px; font-weight: 600; margin-bottom: 12px; }
+    .message { color: #555; line-height: 1.5; margin-bottom: 24px; }
+    .details { font-size: 12px; color: #666; text-align: left; margin-bottom: 24px; overflow-wrap: anywhere; }
+    .actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+    button, .secondary {
+      border-radius: 8px;
+      border: 0;
+      padding: 12px 18px;
+      font: inherit;
+      font-weight: 600;
+      cursor: pointer;
+      text-decoration: none;
+    }
+    button { background: #CC4141; color: white; }
+    .secondary { background: #eee; color: #333; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="title">Cancel Processing?</div>
+    <div class="message">This will stop the current T.I.G.E.R. meeting analysis job. Link previews and security scans cannot cancel it from this page.</div>
+    ${details.executionName ? `<div class="details"><strong>Execution:</strong> ${escapeHtml(details.executionName)}</div>` : ""}
+    <div class="actions">
+      <form method="POST" action="${escapeHtml(request.url)}">
+        <button type="submit">Cancel Processing</button>
+      </form>
+      <a class="secondary" href="javascript:window.close()">Keep Running</a>
+    </div>
+  </div>
+</body>
+</html>`;
+}
+
+function createConfirmationResponse(request, details = {}) {
+  return {
+    status: 200,
+    headers: {
+      "Content-Type": "text/html",
+      "Cache-Control": "no-store",
+      "X-Robots-Tag": "noindex, nofollow",
+    },
+    body: generateCancelConfirmation(request, details),
+  };
+}
+
+function getRequestDiagnostics(request) {
+  return {
+    method: request.method,
+    userAgent: request.headers.get("user-agent") || "",
+    forwardedFor: request.headers.get("x-forwarded-for") || "",
+    referer: request.headers.get("referer") || request.headers.get("referrer") || "",
+  };
+}
+
 /**
  * Return response based on request type (HTML for browser, JSON for API)
  */
@@ -102,9 +190,8 @@ function createResponse(request, success, message, statusCode, details = {}) {
  *   - subscriptionId: Azure subscription ID
  *
  * This function:
- *   1. Tries to look up execution from in-memory cache (same instance)
- *   2. If not found, lists running executions and stops them (cross-instance)
- *   3. Sends a "cancelled" notification to participants
+ *   1. Marks the execution as cancelled so the container can exit cleanly
+ *   2. If execution tracking is unavailable, falls back to stopping the running job
  */
 
 // In-memory store of cancelled executionIds (for check endpoint)
@@ -145,7 +232,23 @@ app.http("CancelProcessing", {
     const subscriptionIdParam = request.query.get("subscriptionId");
     const userId = request.query.get("userId");
 
-    structuredLog(context, "info", "Cancel request received", {
+    if (request.method === "GET") {
+      structuredLog(context, "info", "Cancel confirmation viewed", {
+        ...getRequestDiagnostics(request),
+        executionId,
+        jobName,
+        resourceGroup,
+        subscriptionId: subscriptionIdParam,
+        userId,
+      });
+
+      return createConfirmationResponse(request, {
+        executionName: getExecutionMapping(executionId)?.executionName,
+      });
+    }
+
+    structuredLog(context, "info", "Cancel request submitted", {
+      ...getRequestDiagnostics(request),
       executionId,
       jobName,
       resourceGroup,
@@ -163,16 +266,19 @@ app.http("CancelProcessing", {
       );
     }
 
+    // Mark immediately so the job's cancellation checker can terminate cleanly.
+    markAsCancelled(executionId);
+
     // Try to look up from in-memory cache first (works if same instance)
     const mapping = getExecutionMapping(executionId);
     let executionName = mapping?.executionName;
 
     try {
-      // Get the Container Apps client
-      const client = getContainerAppsClient(subscriptionIdParam);
-
       // If no mapping found, list running executions and find/stop them
       if (!executionName) {
+        // Get the Container Apps client only for the force-stop fallback.
+        const client = getContainerAppsClient(subscriptionIdParam);
+
         structuredLog(
           context,
           "info",
@@ -257,52 +363,16 @@ app.http("CancelProcessing", {
           );
         }
       } else {
-        // Found in cache, stop specific execution
-        structuredLog(context, "info", "Stopping job execution from cache", {
+        // Found in cache, let the container's cancellation checker stop itself.
+        structuredLog(context, "info", "Marked job execution for cooperative cancellation", {
           jobName,
           executionName,
           resourceGroup,
         });
 
-        try {
-          const execution = await client.jobsExecutions.get(
-            resourceGroup,
-            jobName,
-            executionName,
-          );
-
-          if (
-            execution.status === "Running" ||
-            execution.status === "Processing"
-          ) {
-            await client.jobsExecutions.delete(
-              resourceGroup,
-              jobName,
-              executionName,
-            );
-            structuredLog(context, "info", "Job execution stopped", {
-              executionName,
-              previousStatus: execution.status,
-            });
-          } else {
-            structuredLog(context, "info", "Job already completed", {
-              executionName,
-              status: execution.status,
-            });
-          }
-        } catch (stopError) {
-          structuredLog(context, "warn", "Could not stop job execution", {
-            executionName,
-            error: stopError.message,
-          });
-        }
-
         // Remove from mapping cache
         removeExecutionMapping(executionId);
       }
-
-      // Mark as cancelled (for job to check)
-      markAsCancelled(executionId);
 
       return createResponse(
         request,

--- a/azure-function/src/functions/CancelProcessing.js
+++ b/azure-function/src/functions/CancelProcessing.js
@@ -103,7 +103,8 @@ function generateCancelConfirmation(request, details = {}) {
     }
     .title { font-size: 24px; font-weight: 600; margin-bottom: 12px; }
     .message { color: #555; line-height: 1.5; margin-bottom: 24px; }
-    .details { font-size: 12px; color: #666; text-align: left; margin-bottom: 24px; overflow-wrap: anywhere; }
+    .details { font-size: 11px; color: #888; margin-top: 24px; overflow-wrap: anywhere; }
+    .details strong { color: #777; font-weight: 600; }
     .actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
     button, .secondary {
       border-radius: 8px;
@@ -120,15 +121,15 @@ function generateCancelConfirmation(request, details = {}) {
 </head>
 <body>
   <div class="card">
-    <div class="title">Cancel Processing?</div>
-    <div class="message">This will stop the current T.I.G.E.R. meeting analysis job. Link previews and security scans cannot cancel it from this page.</div>
-    ${details.executionName ? `<div class="details"><strong>Execution:</strong> ${escapeHtml(details.executionName)}</div>` : ""}
+    <div class="title">Stop analyzing this meeting?</div>
+    <div class="message">If you stop, the meeting will not be analyzed and no dashboard will be generated.</div>
     <div class="actions">
-      <form method="POST" action="${escapeHtml(request.url)}">
-        <button type="submit">Cancel Processing</button>
-      </form>
       <a class="secondary" href="javascript:window.close()">Keep Running</a>
+      <form method="POST" action="${escapeHtml(request.url)}">
+        <button type="submit">Stop Analysis</button>
+      </form>
     </div>
+    ${details.executionName ? `<div class="details"><strong>Execution:</strong> ${escapeHtml(details.executionName)}</div>` : ""}
   </div>
 </body>
 </html>`;
@@ -146,12 +147,38 @@ function createConfirmationResponse(request, details = {}) {
   };
 }
 
+function isRunningStatus(status) {
+  return status === "Running" || status === "Processing";
+}
+
+async function getExecutionSnapshot(client, resourceGroup, jobName, executionName) {
+  const executions = [];
+  for await (const execution of client.jobsExecutions.list(
+    resourceGroup,
+    jobName,
+  )) {
+    executions.push(execution);
+  }
+
+  const runningExecutions = executions.filter((e) => isRunningStatus(e.status));
+  const targetExecution = executionName
+    ? executions.find((e) => e.name === executionName)
+    : null;
+
+  return {
+    total: executions.length,
+    runningExecutions,
+    targetExecution,
+  };
+}
+
 function getRequestDiagnostics(request) {
   return {
     method: request.method,
     userAgent: request.headers.get("user-agent") || "",
     forwardedFor: request.headers.get("x-forwarded-for") || "",
-    referer: request.headers.get("referer") || request.headers.get("referrer") || "",
+    referer:
+      request.headers.get("referer") || request.headers.get("referrer") || "",
   };
 }
 
@@ -233,6 +260,9 @@ app.http("CancelProcessing", {
     const userId = request.query.get("userId");
 
     if (request.method === "GET") {
+      const mapping = getExecutionMapping(executionId);
+      const executionName = mapping?.executionName;
+
       structuredLog(context, "info", "Cancel confirmation viewed", {
         ...getRequestDiagnostics(request),
         executionId,
@@ -242,9 +272,94 @@ app.http("CancelProcessing", {
         userId,
       });
 
-      return createConfirmationResponse(request, {
-        executionName: getExecutionMapping(executionId)?.executionName,
-      });
+      if (!executionId || !jobName || !resourceGroup || !subscriptionIdParam) {
+        return createResponse(
+          request,
+          false,
+          "Missing required parameters: executionId, jobName, resourceGroup, subscriptionId",
+          400,
+        );
+      }
+
+      try {
+        const client = getContainerAppsClient(subscriptionIdParam);
+        const snapshot = await getExecutionSnapshot(
+          client,
+          resourceGroup,
+          jobName,
+          executionName,
+        );
+
+        structuredLog(context, "info", "Cancel confirmation job status checked", {
+          executionId,
+          executionName,
+          total: snapshot.total,
+          running: snapshot.runningExecutions.length,
+          targetStatus: snapshot.targetExecution?.status,
+        });
+
+        if (snapshot.targetExecution && !isRunningStatus(snapshot.targetExecution.status)) {
+          return createResponse(
+            request,
+            false,
+            "No running job executions found. It may have already completed.",
+            404,
+            { executionId, executionName },
+          );
+        }
+
+        if (!snapshot.targetExecution && executionName) {
+          return createResponse(
+            request,
+            false,
+            "No running job executions found. It may have already completed.",
+            404,
+            { executionId, executionName },
+          );
+        }
+
+        if (!executionName) {
+          if (snapshot.runningExecutions.length === 0) {
+            return createResponse(
+              request,
+              false,
+              "No running job executions found. It may have already completed.",
+              404,
+              { executionId },
+            );
+          }
+
+          if (snapshot.runningExecutions.length > 1) {
+            return createResponse(
+              request,
+              false,
+              `Multiple jobs running (${snapshot.runningExecutions.length}). Cannot safely determine which one to cancel.`,
+              409,
+              { executionId },
+            );
+          }
+
+          return createConfirmationResponse(request, {
+            executionName: snapshot.runningExecutions[0].name,
+          });
+        }
+
+        return createConfirmationResponse(request, { executionName });
+      } catch (err) {
+        structuredLog(context, "warn", "Could not verify job status for cancel confirmation", {
+          executionId,
+          executionName,
+          error: err.message,
+        });
+
+        return createResponse(
+          request,
+          false,
+          "Could not verify whether the job is still running. Please try again.",
+          500,
+          { executionId, executionName },
+        );
+      }
     }
 
     structuredLog(context, "info", "Cancel request submitted", {
@@ -289,22 +404,15 @@ app.http("CancelProcessing", {
           },
         );
 
-        // List all executions for this job
-        const executions = [];
-        for await (const execution of client.jobsExecutions.list(
+        const snapshot = await getExecutionSnapshot(
+          client,
           resourceGroup,
           jobName,
-        )) {
-          executions.push(execution);
-        }
-
-        // Find running executions
-        const runningExecutions = executions.filter(
-          (e) => e.status === "Running" || e.status === "Processing",
         );
+        const { runningExecutions } = snapshot;
 
         structuredLog(context, "info", "Found executions", {
-          total: executions.length,
+          total: snapshot.total,
           running: runningExecutions.length,
         });
 
@@ -364,11 +472,16 @@ app.http("CancelProcessing", {
         }
       } else {
         // Found in cache, let the container's cancellation checker stop itself.
-        structuredLog(context, "info", "Marked job execution for cooperative cancellation", {
-          jobName,
-          executionName,
-          resourceGroup,
-        });
+        structuredLog(
+          context,
+          "info",
+          "Marked job execution for cooperative cancellation",
+          {
+            jobName,
+            executionName,
+            resourceGroup,
+          },
+        );
 
         // Remove from mapping cache
         removeExecutionMapping(executionId);

--- a/azure-function/src/functions/CancelProcessing.js
+++ b/azure-function/src/functions/CancelProcessing.js
@@ -151,7 +151,12 @@ function isRunningStatus(status) {
   return status === "Running" || status === "Processing";
 }
 
-async function getExecutionSnapshot(client, resourceGroup, jobName, executionName) {
+async function getExecutionSnapshot(
+  client,
+  resourceGroup,
+  jobName,
+  executionName,
+) {
   const executions = [];
   for await (const execution of client.jobsExecutions.list(
     resourceGroup,
@@ -290,15 +295,23 @@ app.http("CancelProcessing", {
           executionName,
         );
 
-        structuredLog(context, "info", "Cancel confirmation job status checked", {
-          executionId,
-          executionName,
-          total: snapshot.total,
-          running: snapshot.runningExecutions.length,
-          targetStatus: snapshot.targetExecution?.status,
-        });
+        structuredLog(
+          context,
+          "info",
+          "Cancel confirmation job status checked",
+          {
+            executionId,
+            executionName,
+            total: snapshot.total,
+            running: snapshot.runningExecutions.length,
+            targetStatus: snapshot.targetExecution?.status,
+          },
+        );
 
-        if (snapshot.targetExecution && !isRunningStatus(snapshot.targetExecution.status)) {
+        if (
+          snapshot.targetExecution &&
+          !isRunningStatus(snapshot.targetExecution.status)
+        ) {
           return createResponse(
             request,
             false,
@@ -346,11 +359,16 @@ app.http("CancelProcessing", {
 
         return createConfirmationResponse(request, { executionName });
       } catch (err) {
-        structuredLog(context, "warn", "Could not verify job status for cancel confirmation", {
-          executionId,
-          executionName,
-          error: err.message,
-        });
+        structuredLog(
+          context,
+          "warn",
+          "Could not verify job status for cancel confirmation",
+          {
+            executionId,
+            executionName,
+            error: err.message,
+          },
+        );
 
         return createResponse(
           request,
@@ -380,9 +398,6 @@ app.http("CancelProcessing", {
         400,
       );
     }
-
-    // Mark immediately so the job's cancellation checker can terminate cleanly.
-    markAsCancelled(executionId);
 
     // Try to look up from in-memory cache first (works if same instance)
     const mapping = getExecutionMapping(executionId);
@@ -458,6 +473,8 @@ app.http("CancelProcessing", {
             previousStatus: targetExecution.status,
           });
           executionName = targetExecution.name;
+          // Mark as cancelled only after the force-stop succeeded
+          markAsCancelled(executionId);
         } catch (stopError) {
           structuredLog(context, "warn", "Could not stop job execution", {
             executionName: targetExecution.name,
@@ -483,6 +500,8 @@ app.http("CancelProcessing", {
           },
         );
 
+        // Mark as cancelled only after confirming the cooperative path is valid
+        markAsCancelled(executionId);
         // Remove from mapping cache
         removeExecutionMapping(executionId);
       }

--- a/azure-function/src/functions/CancelProcessing.js
+++ b/azure-function/src/functions/CancelProcessing.js
@@ -227,9 +227,29 @@ function createResponse(request, success, message, statusCode, details = {}) {
  *   2. Stops the execution through the Container Apps API after explicit confirmation
  */
 
-// Legacy in-memory store for CheckCancellation.
-// Explicit cancellation now stops the Container App Job execution directly.
+// Best-effort in-memory cancellation marker used only so the running container
+// can classify the SIGTERM as user-cancelled and send a "cancelled" Teams
+// notification with the same participant metadata as failed/completed notices.
+// TODO: Move this marker to shared storage (Cosmos/Table/Blob) so
+// CheckCancellation works reliably across multiple Azure Function instances.
 const cancelledExecutions = new Set();
+const cancelledTimestamps = new Map();
+const CANCELLED_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+function markAsCancelled(executionId) {
+  cancelledExecutions.add(executionId);
+  cancelledTimestamps.set(executionId, Date.now());
+
+  if (cancelledExecutions.size > 100) {
+    const now = Date.now();
+    for (const [id, ts] of cancelledTimestamps) {
+      if (now - ts > CANCELLED_TTL_MS) {
+        cancelledExecutions.delete(id);
+        cancelledTimestamps.delete(id);
+      }
+    }
+  }
+}
 
 function isCancelled(executionId) {
   return cancelledExecutions.has(executionId);
@@ -445,7 +465,8 @@ app.http("CancelProcessing", {
         // Stop the single running execution
         const targetExecution = runningExecutions[0];
         try {
-          await client.jobsExecutions.delete(
+          markAsCancelled(executionId);
+          await client.jobs.beginStopExecutionAndWait(
             resourceGroup,
             jobName,
             targetExecution.name,
@@ -489,18 +510,18 @@ app.http("CancelProcessing", {
           );
         }
 
-        await client.jobsExecutions.delete(resourceGroup, jobName, executionName);
-        structuredLog(
-          context,
-          "info",
-          "Job execution stopped from cache",
-          {
-            jobName,
-            executionName,
-            resourceGroup,
-            previousStatus: snapshot.targetExecution.status,
-          },
+        markAsCancelled(executionId);
+        await client.jobs.beginStopExecutionAndWait(
+          resourceGroup,
+          jobName,
+          executionName,
         );
+        structuredLog(context, "info", "Job execution stopped from cache", {
+          jobName,
+          executionName,
+          resourceGroup,
+          previousStatus: snapshot.targetExecution.status,
+        });
 
         // Remove from mapping cache
         removeExecutionMapping(executionId);

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,9 +40,9 @@ start_cancel_checker() {
             if [ "$IS_CANCELLED" = "true" ]; then
                 log "info" "Job cancelled by user, terminating..."
                 touch "$CANCELLED_FILE"
-                # Kill the process group so any foreground Node/Claude child exits too.
+                # Kill the current process group so any foreground Node/Claude child exits too.
                 # The main shell traps this and exits 0 for user-requested cancellation.
-                kill -TERM -$$ 2>/dev/null || true
+                kill -TERM 0 2>/dev/null || true
                 exit 0
             fi
         done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,13 +16,44 @@ log() {
 # Polls CHECK_CANCELLATION_URL every 15 seconds and exits if cancelled
 CANCEL_CHECKER_PID=""
 CANCELLED_FILE="/tmp/tiger-cancelled"
+CANCELLED_NOTIFIED_FILE="/tmp/tiger-cancelled-notified"
+
+send_cancelled_notification() {
+    if [ -f "$CANCELLED_NOTIFIED_FILE" ]; then
+        return
+    fi
+
+    if [ -z "$LOGIC_APP_URL" ] || [ -z "$PARTICIPANTS_JSON" ]; then
+        return
+    fi
+
+    touch "$CANCELLED_NOTIFIED_FILE"
+    NOTIFICATION_TYPE="cancelled" node processor/sendNotification.js >/dev/null || true
+}
+
+is_user_cancelled() {
+    if [ -f "$CANCELLED_FILE" ]; then
+        echo "true"
+        return
+    fi
+
+    if [ -z "$CHECK_CANCELLATION_URL" ]; then
+        echo "false"
+        return
+    fi
+
+    local cancel_check
+    cancel_check=$(curl -s --max-time 3 "$CHECK_CANCELLATION_URL" 2>/dev/null || echo '{"cancelled":false}')
+    echo "$cancel_check" | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin').toString()).cancelled" 2>/dev/null || echo "false"
+}
 
 handle_termination() {
     local signal_name="$1"
     local exit_code="$2"
 
-    if [ -f "$CANCELLED_FILE" ]; then
+    if [ "$signal_name" = "TERM" ] && [ "$(is_user_cancelled)" = "true" ]; then
         log "info" "Cancellation signal received, exiting successfully"
+        send_cancelled_notification
         exit 0
     fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -13,8 +13,19 @@ log() {
 }
 
 # Background cancellation checker
-# Polls CHECK_CANCELLATION_URL every 5 seconds and exits if cancelled
+# Polls CHECK_CANCELLATION_URL every 15 seconds and exits if cancelled
 CANCEL_CHECKER_PID=""
+CANCELLED_FILE="/tmp/tiger-cancelled"
+
+handle_termination() {
+    if [ -f "$CANCELLED_FILE" ]; then
+        log "info" "Cancellation signal received, exiting successfully"
+        exit 0
+    fi
+
+    log "warn" "Termination signal received"
+    exit 143
+}
 
 start_cancel_checker() {
     if [ -z "$CHECK_CANCELLATION_URL" ]; then
@@ -28,7 +39,9 @@ start_cancel_checker() {
             IS_CANCELLED=$(echo "$CANCEL_CHECK" | node -pe "JSON.parse(require('fs').readFileSync('/dev/stdin').toString()).cancelled" 2>/dev/null || echo "false")
             if [ "$IS_CANCELLED" = "true" ]; then
                 log "info" "Job cancelled by user, terminating..."
-                # Kill the parent process group
+                touch "$CANCELLED_FILE"
+                # Kill the process group so any foreground Node/Claude child exits too.
+                # The main shell traps this and exits 0 for user-requested cancellation.
                 kill -TERM -$$ 2>/dev/null || true
                 exit 0
             fi
@@ -45,6 +58,7 @@ stop_cancel_checker() {
 
 # Cleanup on exit
 trap stop_cancel_checker EXIT
+trap handle_termination TERM INT
 
 # Setup Claude CLI authentication
 setup_claude_auth() {
@@ -86,7 +100,7 @@ send_failure_notification() {
 
 # Main pipeline
 run_pipeline() {
-    # Start background cancellation checker (polls every 5s)
+    # Start background cancellation checker (polls every 15s)
     start_cancel_checker
 
     # Step 1: Download transcript

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,13 +18,16 @@ CANCEL_CHECKER_PID=""
 CANCELLED_FILE="/tmp/tiger-cancelled"
 
 handle_termination() {
+    local signal_name="$1"
+    local exit_code="$2"
+
     if [ -f "$CANCELLED_FILE" ]; then
         log "info" "Cancellation signal received, exiting successfully"
         exit 0
     fi
 
-    log "warn" "Termination signal received"
-    exit 143
+    log "warn" "$signal_name signal received"
+    exit "$exit_code"
 }
 
 start_cancel_checker() {
@@ -58,7 +61,8 @@ stop_cancel_checker() {
 
 # Cleanup on exit
 trap stop_cancel_checker EXIT
-trap handle_termination TERM INT
+trap 'handle_termination TERM 143' TERM
+trap 'handle_termination INT 130' INT
 
 # Setup Claude CLI authentication
 setup_claude_auth() {


### PR DESCRIPTION
## What changed

This PR fixes accidental job cancellation from cancel-link visits (#104) and improves the cancellation flow.

Changes:
- Makes `GET /CancelProcessing` non-destructive.
- Shows a confirmation page before stopping analysis.
- Requires `POST /CancelProcessing` to actually cancel a job.
- Checks whether the target Container App Job execution is still running before showing the stop button.
- Shows “No running job executions found. It may have already completed.” when the job is already finished or cannot be found.
- Uses the correct Azure Container Apps SDK stop API: `client.jobs.beginStopExecutionAndWait(...)`.
- Removes the invalid `client.jobsExecutions.delete(...)` usage.
- Adds request diagnostics to cancellation logs: method, user agent, forwarded IP, and referer.
- Sends best-effort `cancelled` Teams notifications from inside the container when cancellation is confirmed.
- Reuses the container’s existing notification metadata so cancelled notifications can go to the same participant list as failed/completed notifications.
- Updates signal handling so `SIGTERM` exits `143`, `SIGINT` exits `130`, and user-requested cancellation can exit `0`.
- Removes the `javascript:window.close()` link from the confirmation page.
- Updates the confirmation page copy and layout.

## Why it worked before but started failing now

The old cancellation endpoint accepted both `GET` and `POST`, and a `GET` request immediately cancelled the job.

That worked for months because nothing was regularly visiting the cancel URL before the user clicked it. Recently, something in the message/link path appears to have started touching the URL automatically, likely one of:

- Microsoft Defender Safe Links scanning
- Teams link preview or URL safety checks
- Browser/mobile client prefetching
- Tenant security policy changes or rollout behavior

The Azure logs showed `CancelProcessing` being invoked even when the user had not clicked the cancel button. Once that endpoint was invoked, it marked the execution as cancelled, then the container’s `CheckCancellation` poll saw the cancelled state and terminated the job.

The root issue was that cancellation was implemented as a destructive `GET`, which is unsafe because links can be visited by systems other than the user.

## Fix

`GET /CancelProcessing` now only renders a confirmation/status page.

The actual cancellation only happens when the user submits the confirmation form, which sends `POST /CancelProcessing`.

The confirmation page checks Container App Job execution status first:
- If the execution is still `Running` or `Processing`, the user sees the stop confirmation.
- If the execution has already completed, failed, or cannot be found, the user sees a completed/not-running message instead.
- If there are multiple running jobs and the specific execution cannot be identified, the page refuses to cancel because it cannot safely determine which job to stop.

On confirmed cancel, the Function marks the execution as cancelled, then stops the Container App Job execution using `client.jobs.beginStopExecutionAndWait(...)`.

The container handles user cancellation as a best-effort graceful path:
- It receives `SIGTERM`.
- It calls `CheckCancellation`.
- If cancellation is confirmed, it sends `NOTIFICATION_TYPE=cancelled` through the existing notification script.
- It exits `0` for user-requested cancellation.

## Cancelled notification behavior

Cancelled notifications are sent from inside the container, not directly from the Azure Function.

This lets cancelled notifications reuse the same metadata already available for failed/completed notifications:

- `PARTICIPANTS_JSON`
- `MEETING_SUBJECT`
- `PROJECT_NAME`
- `MEETING_DURATION`

That means cancelled notifications can go to the same participant list as failed/completed notifications.

## Known limitation / TODO

The cancelled marker currently uses Azure Function in-memory state.

That means the cancelled Teams notification is best-effort only: if `CheckCancellation` is served by a different Function instance than the one that handled the cancel POST, the container may not see the cancelled marker before it is stopped.

The job stop itself is reliable because it uses the Container Apps API, but the cancelled Teams notification can still be missed in a cross-instance case.

TODO:
- Move the cancellation marker to shared storage, such as Cosmos DB, Azure Table Storage, or Blob Storage.
- Make `CheckCancellation` read from that shared store.
- Keep the current ARM stop as the reliable fallback.

## User impact

Users now get an explicit confirmation step before stopping analysis.

Security scanners, link previews, or accidental URL visits can no longer cancel a meeting analysis job.

If the job has already finished by the time the user opens the cancel link, the page tells them it has likely completed instead of showing a misleading stop button.

When cancellation is confirmed and the container observes the cancellation marker, participants receive a cancelled Teams notification.

## Validation

- Confirmed the previous Azure logs showed `CancelProcessing` being invoked before `CheckCancellation` returned cancelled.
- Verified the Azure SDK exposes `beginStopExecutionAndWait(...)` on `client.jobs`; `jobsExecutions` only supports `list()`.
- Removed usage of the invalid `client.jobsExecutions.delete(...)`.
- Verified `entrypoint.sh` syntax with `bash -n entrypoint.sh`.