### PR TITLE
Add restart button to rerun the job

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ AzuriteConfig
 
 # Bicep outputs
 infra/main.json
+
+# AI agents folders
+.agents
+.codex

--- a/azure-function/src/functions/ProcessTranscriptQueue.js
+++ b/azure-function/src/functions/ProcessTranscriptQueue.js
@@ -107,6 +107,23 @@ function removeExecutionMapping(executionId) {
   executionMappingCache.delete(executionId);
 }
 
+/**
+ * Find a cached execution mapping for a given meeting + transcript.
+ * Used by RestartProcessing to detect a job already running for the meeting.
+ *
+ * Per-instance only — if the running job was started by a different Function
+ * instance, this returns undefined. Caller should treat that as "no match" and
+ * rely on the live Container Apps API check + queue-level dedup as backstops.
+ */
+function findActiveExecutionForMeeting(meetingId, transcriptId) {
+  for (const [executionId, data] of executionMappingCache) {
+    if (data.meetingId === meetingId && data.transcriptId === transcriptId) {
+      return { executionId, ...data };
+    }
+  }
+  return undefined;
+}
+
 function getContainerAppsClient(subscriptionId) {
   if (!containerAppsClient) {
     azureCredential = new DefaultAzureCredential();
@@ -137,7 +154,7 @@ app.storageQueue("ProcessTranscriptQueue", {
       data = message;
     }
 
-    const { userId, meetingId, transcriptId, skipSubjectFilter, manualTrigger } = data;
+    const { userId, meetingId, transcriptId, skipSubjectFilter, manualTrigger, restartTrigger, restartId, restartedFromExecutionId } = data;
 
     if (!userId || !meetingId || !transcriptId) {
       structuredLog(context, "error", "Missing IDs in queue message", { userId, meetingId, transcriptId });
@@ -148,12 +165,36 @@ app.storageQueue("ProcessTranscriptQueue", {
       structuredLog(context, "info", "Manual trigger - subject filter will be skipped", { meetingId });
     }
 
-    // Check for duplicate (Graph may send same notification multiple times)
-    // Manual triggers use a separate dedup key so they aren't blocked by webhook entries,
-    // but still dedup against each other (prevents double-click spawning two containers)
-    const dedupKey = manualTrigger ? `manual-${meetingId}-${transcriptId}` : `${meetingId}-${transcriptId}`;
+    if (restartTrigger) {
+      structuredLog(context, "info", "Restart job starting", {
+        meetingId,
+        transcriptId,
+        restartedFromExecutionId: restartedFromExecutionId || "(unknown)",
+      });
+    }
+
+    // Check for duplicate (Graph may send same notification multiple times).
+    // Webhook/manual: dedup on meetingId+transcriptId (10 min) — covers
+    //   Graph webhook retries and accidental UI double-clicks.
+    // Restart: dedup on a per-click unique restartId — only prevents Azure
+    //   Queue redelivery of the same message; multiple legitimate restart
+    //   clicks each get their own restartId. RestartProcessing blocks rapid
+    //   user double-clicks before enqueueing.
+    let dedupKey;
+    if (restartTrigger) {
+      dedupKey = `restart-${restartId || `${meetingId}-${transcriptId}-${Date.now()}`}`;
+    } else if (manualTrigger) {
+      dedupKey = `manual-${meetingId}-${transcriptId}`;
+    } else {
+      dedupKey = `${meetingId}-${transcriptId}`;
+    }
     if (processedCache.has(dedupKey) && Date.now() - processedCache.get(dedupKey) < CACHE_TTL_MS) {
-      structuredLog(context, "info", "SKIP: Duplicate notification", { meetingId, transcriptId, manualTrigger: !!manualTrigger });
+      structuredLog(context, "info", "SKIP: Duplicate notification", {
+        meetingId,
+        transcriptId,
+        manualTrigger: !!manualTrigger,
+        restartTrigger: !!restartTrigger,
+      });
       return;
     }
 
@@ -209,8 +250,15 @@ async function triggerContainerAppJob(params, context) {
   // Build cancel URL if cancel function is configured
   // Include subscriptionId so cancel can work without in-memory cache (cross-instance)
   // Include userId so cancelled notification can be sent to the organizer
+  // Include meetingId/transcriptId so the cancel-success page can build a Restart link
   const cancelUrl = cancelFunctionUrl
-    ? `${cancelFunctionUrl}?executionId=${encodeURIComponent(executionId)}&jobName=${encodeURIComponent(jobName)}&resourceGroup=${encodeURIComponent(resourceGroup)}&subscriptionId=${encodeURIComponent(subscriptionId)}&userId=${encodeURIComponent(userId)}`
+    ? `${cancelFunctionUrl}?executionId=${encodeURIComponent(executionId)}&jobName=${encodeURIComponent(jobName)}&resourceGroup=${encodeURIComponent(resourceGroup)}&subscriptionId=${encodeURIComponent(subscriptionId)}&userId=${encodeURIComponent(userId)}&meetingId=${encodeURIComponent(meetingId)}&transcriptId=${encodeURIComponent(transcriptId)}`
+    : "";
+
+  // Build restart URL (same Function host, different endpoint)
+  const restartUrl = cancelFunctionUrl
+    ? cancelFunctionUrl.replace("/CancelProcessing", "/RestartProcessing") +
+      `?executionId=${encodeURIComponent(executionId)}&userId=${encodeURIComponent(userId)}&meetingId=${encodeURIComponent(meetingId)}&transcriptId=${encodeURIComponent(transcriptId)}`
     : "";
 
   // Build check cancellation URL (same host, different endpoint)
@@ -242,6 +290,8 @@ async function triggerContainerAppJob(params, context) {
               { name: "JOB_EXECUTION_ID", value: executionId },
               { name: "CANCEL_URL", value: cancelUrl },
               { name: "CHECK_CANCELLATION_URL", value: checkCancellationUrl },
+              // Restart URL — sent in failed/cancelled Teams cards so users can re-run
+              { name: "RESTART_URL", value: restartUrl },
               // Manual trigger: skip subject filter when explicitly requested
               ...(skipSubjectFilter
                 ? [{ name: "SKIP_SUBJECT_FILTER", value: "true" }]
@@ -272,12 +322,16 @@ async function triggerContainerAppJob(params, context) {
     const executionName = initialResult?.name || "unknown";
 
     // Store mapping of executionId -> executionName for cancel functionality
-    // This allows the cancel endpoint to find the actual job execution
+    // This allows the cancel endpoint to find the actual job execution.
+    // meetingId/transcriptId enable findActiveExecutionForMeeting() (used by RestartProcessing
+    // to detect a job already running for the same meeting).
     storeExecutionMapping(executionId, {
       executionName,
       jobName,
       resourceGroup,
       subscriptionId,
+      meetingId,
+      transcriptId,
       startedAt: Date.now(),
     });
 
@@ -302,11 +356,12 @@ async function triggerContainerAppJob(params, context) {
   }
 }
 
-// Export shared utilities for CancelProcessing function
+// Export shared utilities for CancelProcessing and RestartProcessing functions
 module.exports = {
   getContainerAppsClient,
   getExecutionMapping,
   removeExecutionMapping,
+  findActiveExecutionForMeeting,
   structuredLog,
   LOG_PREFIX,
 };

--- a/azure-function/src/functions/ProcessTranscriptQueue.js
+++ b/azure-function/src/functions/ProcessTranscriptQueue.js
@@ -1,6 +1,7 @@
 const { app } = require("@azure/functions");
 const { DefaultAzureCredential } = require("@azure/identity");
 const { ContainerAppsAPIClient } = require("@azure/arm-appcontainers");
+const crypto = require("crypto");
 
 /**
  * Processes transcript notifications from the queue.
@@ -84,6 +85,7 @@ function removeFromCache(meetingId, transcriptId) {
  */
 const executionMappingCache = new Map();
 const EXECUTION_CACHE_TTL_MS = 2 * 60 * 60 * 1000; // 2 hours
+const RESTART_TOKEN_TTL_MS = 14 * 24 * 60 * 60 * 1000; // 14 days
 
 function storeExecutionMapping(executionId, data) {
   executionMappingCache.set(executionId, data);
@@ -133,6 +135,63 @@ function getContainerAppsClient(subscriptionId) {
     );
   }
   return containerAppsClient;
+}
+
+function getRestartTokenSecret() {
+  return (
+    process.env.RESTART_TOKEN_SECRET ||
+    process.env.WEBHOOK_CLIENT_STATE ||
+    process.env.GRAPH_CLIENT_SECRET
+  );
+}
+
+function createRestartSignature({
+  executionId,
+  userId,
+  meetingId,
+  transcriptId,
+  expiresAt,
+}) {
+  const secret = getRestartTokenSecret();
+  if (!secret) {
+    throw new Error(
+      "Missing restart token signing secret. Configure RESTART_TOKEN_SECRET, WEBHOOK_CLIENT_STATE, or GRAPH_CLIENT_SECRET.",
+    );
+  }
+
+  return crypto
+    .createHmac("sha256", secret)
+    .update(
+      [executionId, userId, meetingId, transcriptId, String(expiresAt)].join(
+        "|",
+      ),
+    )
+    .digest("hex");
+}
+
+function appendQueryParams(url, params) {
+  const parsedUrl = new URL(url);
+  for (const [key, value] of Object.entries(params)) {
+    parsedUrl.searchParams.set(key, value);
+  }
+  return parsedUrl.toString();
+}
+
+function buildSiblingFunctionUrl(sourceFunctionUrl, targetFunctionName) {
+  const parsedUrl = new URL(sourceFunctionUrl);
+  const normalizedPath = parsedUrl.pathname.replace(/\/+$/, "");
+  if (!normalizedPath.endsWith("/CancelProcessing")) {
+    throw new Error(
+      `CANCEL_FUNCTION_URL must end with /CancelProcessing to derive ${targetFunctionName}`,
+    );
+  }
+  parsedUrl.pathname = `${normalizedPath.slice(
+    0,
+    -"/CancelProcessing".length,
+  )}/${targetFunctionName}`;
+  parsedUrl.search = "";
+  parsedUrl.hash = "";
+  return parsedUrl.toString();
 }
 
 app.storageQueue("ProcessTranscriptQueue", {
@@ -246,24 +305,57 @@ async function triggerContainerAppJob(params, context) {
 
   // Generate a unique execution ID for this job run
   const executionId = `${meetingId}-${transcriptId}-${Date.now()}`;
+  const restartTokenExpiresAt = cancelFunctionUrl
+    ? Date.now() + RESTART_TOKEN_TTL_MS
+    : null;
+  const restartToken = cancelFunctionUrl
+    ? createRestartSignature({
+        executionId,
+        userId,
+        meetingId,
+        transcriptId,
+        expiresAt: restartTokenExpiresAt,
+      })
+    : "";
 
   // Build cancel URL if cancel function is configured
   // Include subscriptionId so cancel can work without in-memory cache (cross-instance)
   // Include userId so cancelled notification can be sent to the organizer
-  // Include meetingId/transcriptId so the cancel-success page can build a Restart link
   const cancelUrl = cancelFunctionUrl
-    ? `${cancelFunctionUrl}?executionId=${encodeURIComponent(executionId)}&jobName=${encodeURIComponent(jobName)}&resourceGroup=${encodeURIComponent(resourceGroup)}&subscriptionId=${encodeURIComponent(subscriptionId)}&userId=${encodeURIComponent(userId)}&meetingId=${encodeURIComponent(meetingId)}&transcriptId=${encodeURIComponent(transcriptId)}`
+    ? appendQueryParams(cancelFunctionUrl, {
+        executionId,
+        jobName,
+        resourceGroup,
+        subscriptionId,
+        userId,
+        meetingId,
+        transcriptId,
+      })
     : "";
 
   // Build restart URL (same Function host, different endpoint)
   const restartUrl = cancelFunctionUrl
-    ? cancelFunctionUrl.replace("/CancelProcessing", "/RestartProcessing") +
-      `?executionId=${encodeURIComponent(executionId)}&userId=${encodeURIComponent(userId)}&meetingId=${encodeURIComponent(meetingId)}&transcriptId=${encodeURIComponent(transcriptId)}`
+    ? appendQueryParams(
+        buildSiblingFunctionUrl(cancelFunctionUrl, "RestartProcessing"),
+        {
+          executionId,
+          userId,
+          meetingId,
+          transcriptId,
+          expiresAt: String(restartTokenExpiresAt),
+          token: restartToken,
+        },
+      )
     : "";
 
   // Build check cancellation URL (same host, different endpoint)
   const checkCancellationUrl = cancelFunctionUrl
-    ? cancelFunctionUrl.replace("/CancelProcessing", "/CheckCancellation") + `?executionId=${encodeURIComponent(executionId)}`
+    ? appendQueryParams(
+        buildSiblingFunctionUrl(cancelFunctionUrl, "CheckCancellation"),
+        {
+          executionId,
+        },
+      )
     : "";
 
   // Use singleton client for better performance

--- a/azure-function/src/functions/RestartProcessing.js
+++ b/azure-function/src/functions/RestartProcessing.js
@@ -1,0 +1,443 @@
+const { app, output } = require("@azure/functions");
+const crypto = require("crypto");
+const {
+  getContainerAppsClient,
+  findActiveExecutionForMeeting,
+  structuredLog,
+} = require("./ProcessTranscriptQueue");
+
+/**
+ * HTTP trigger to restart a transcript processing job for the same meeting.
+ * Called when the user clicks "Restart processing" on a "cancelled" or
+ * "failed" Teams card, or on the cancel-success HTML page.
+ *
+ * Query parameters:
+ *   - executionId   : original execution ID (for audit/correlation; pseudo-token)
+ *   - userId        : Graph user ID of the meeting organizer
+ *   - meetingId     : Graph meeting ID
+ *   - transcriptId  : Graph transcript ID
+ *
+ * Concurrency defence:
+ *   1. List Container App Job executions and check if one is already running
+ *      for this meeting (matched via the shared executionMappingCache).
+ *   2. In-process restart-in-flight set blocks rapid double-clicks within the
+ *      window between this endpoint and ProcessTranscriptQueue picking up the
+ *      message.
+ *   3. ProcessTranscriptQueue has its own dedup keyed by `restart-${meetingId}-${transcriptId}`.
+ */
+
+// In-memory tracking of restart requests issued in the last 30 seconds.
+// Key: `${meetingId}-${transcriptId}` — Value: timestamp.
+//
+// Purpose: bridge the brief window between this endpoint enqueuing a message
+// and ProcessTranscriptQueue picking it up and starting a container. Once the
+// container starts, executionMappingCache picks up the slack and Layer 1
+// (Azure API check) handles further restart attempts.
+//
+// 30s is enough to absorb double-clicks from a single user; a longer TTL
+// would block legitimate retries when a freshly-started container fails fast.
+const restartInFlight = new Map();
+const RESTART_INFLIGHT_TTL_MS = 30 * 1000;
+
+function markRestartInFlight(meetingId, transcriptId) {
+  restartInFlight.set(`${meetingId}-${transcriptId}`, Date.now());
+
+  // Cleanup old entries to prevent memory growth
+  if (restartInFlight.size > 200) {
+    const now = Date.now();
+    for (const [k, ts] of restartInFlight) {
+      if (now - ts > RESTART_INFLIGHT_TTL_MS) {
+        restartInFlight.delete(k);
+      }
+    }
+  }
+}
+
+function isRestartInFlight(meetingId, transcriptId) {
+  const key = `${meetingId}-${transcriptId}`;
+  const ts = restartInFlight.get(key);
+  if (!ts) return false;
+  if (Date.now() - ts > RESTART_INFLIGHT_TTL_MS) {
+    restartInFlight.delete(key);
+    return false;
+  }
+  return true;
+}
+
+function executionMatchesMeeting(execution, meetingId, transcriptId) {
+  const containers = execution?.template?.containers;
+  if (!Array.isArray(containers)) return false;
+  for (const c of containers) {
+    if (!Array.isArray(c.env)) continue;
+    const envMap = new Map(c.env.map((e) => [e.name, e.value]));
+    if (
+      envMap.get("GRAPH_MEETING_ID") === meetingId &&
+      envMap.get("GRAPH_TRANSCRIPT_ID") === transcriptId
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function generateHtmlResponse(success, message, details = {}) {
+  // Three states: success (green), conflict (amber), error (red)
+  const isConflict = details.conflict === true;
+  const icon = success ? "🐯" : isConflict ? "⏳" : "❌";
+  const title = success
+    ? "Restart Queued"
+    : isConflict
+      ? "Already Running"
+      : "Restart Failed";
+  const bgColor = success ? "#d4edda" : isConflict ? "#fff3cd" : "#f8d7da";
+  const textColor = success ? "#155724" : isConflict ? "#856404" : "#721c24";
+  const borderColor = success ? "#c3e6cb" : isConflict ? "#ffeaa7" : "#f5c6cb";
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>${title} - SSW Tiger</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f5f5f5;
+    }
+    .card {
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+      padding: 40px;
+      text-align: center;
+      max-width: 400px;
+    }
+    .icon { font-size: 64px; margin-bottom: 20px; }
+    .title { font-size: 24px; font-weight: 600; margin-bottom: 12px; color: #333; }
+    .message {
+      padding: 16px;
+      border-radius: 8px;
+      background: ${bgColor};
+      color: ${textColor};
+      border: 1px solid ${borderColor};
+      margin-bottom: 20px;
+    }
+    .close-hint { margin-top: 20px; color: #999; font-size: 14px; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">${icon}</div>
+    <div class="title">${title}</div>
+    <div class="message">${message}</div>
+    <div class="close-hint">You can close this window now.</div>
+  </div>
+</body>
+</html>`;
+}
+
+function createResponse(request, success, message, statusCode, details = {}) {
+  const acceptHeader = request.headers.get("accept") || "";
+  const isJsonRequest = acceptHeader.includes("application/json");
+
+  if (isJsonRequest) {
+    return {
+      status: statusCode,
+      jsonBody: success
+        ? { success: true, message, ...details }
+        : { error: true, message, ...details },
+    };
+  }
+
+  return {
+    status: statusCode,
+    headers: { "Content-Type": "text/html" },
+    body: generateHtmlResponse(success, message, details),
+  };
+}
+
+function generateConfirmationResponse(request) {
+  return {
+    status: 200,
+    headers: { "Content-Type": "text/html" },
+    body: `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Restart Processing - SSW Tiger</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      min-height: 100vh;
+      margin: 0;
+      background: #f5f5f5;
+    }
+    .card {
+      background: white;
+      border-radius: 12px;
+      box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+      padding: 40px;
+      text-align: center;
+      max-width: 400px;
+    }
+    .icon { font-size: 64px; margin-bottom: 20px; }
+    .title { font-size: 24px; font-weight: 600; margin-bottom: 12px; color: #333; }
+    .message {
+      padding: 16px;
+      border-radius: 8px;
+      background: #fff3cd;
+      color: #856404;
+      border: 1px solid #ffeaa7;
+      margin-bottom: 20px;
+    }
+    .action-button {
+      display: inline-block;
+      margin-top: 8px;
+      padding: 12px 24px;
+      background: #cc0000;
+      color: white;
+      border: none;
+      border-radius: 6px;
+      font-size: 16px;
+      font-weight: 600;
+      cursor: pointer;
+    }
+    .close-hint { margin-top: 20px; color: #999; font-size: 14px; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="icon">↻</div>
+    <div class="title">Restart Processing?</div>
+    <div class="message">This will re-run the meeting analysis from scratch.</div>
+    <form method="POST" action="${request.url}">
+      <button type="submit" class="action-button">↻ Confirm Restart</button>
+    </form>
+    <div class="close-hint">You can close this window if you do not want to restart.</div>
+  </div>
+</body>
+</html>`,
+  };
+}
+
+// Same queue used by TranscriptWebhook and TriggerProcessing
+const queueOutput = output.storageQueue({
+  queueName: "transcript-notifications",
+  connection: "AzureWebJobsStorage",
+});
+
+app.http("RestartProcessing", {
+  methods: ["POST", "GET"],
+  authLevel: "anonymous",
+  extraOutputs: [queueOutput],
+  handler: async (request, context) => {
+    const executionId = request.query.get("executionId");
+    const userId = request.query.get("userId");
+    const meetingId = request.query.get("meetingId");
+    const transcriptId = request.query.get("transcriptId");
+    const sourceIp =
+      request.headers.get("x-forwarded-for") ||
+      request.headers.get("x-azure-clientip") ||
+      "(unknown)";
+
+    structuredLog(context, "info", "Restart request received", {
+      executionId,
+      userId,
+      meetingId,
+      transcriptId,
+      method: request.method,
+      sourceIp,
+    });
+
+    // Validate required parameters
+    const missing = [];
+    if (!executionId) missing.push("executionId");
+    if (!userId) missing.push("userId");
+    if (!meetingId) missing.push("meetingId");
+    if (!transcriptId) missing.push("transcriptId");
+
+    if (missing.length > 0) {
+      return createResponse(
+        request,
+        false,
+        `Missing required parameter(s): ${missing.join(", ")}`,
+        400,
+      );
+    }
+
+    // Teams and security scanners can prefetch links with GET. GET must be
+    // side-effect free; only the confirmation form's POST may enqueue a run.
+    if (request.method === "GET") {
+      return generateConfirmationResponse(request);
+    }
+
+    // Layer 1: Live check via Container Apps API + in-memory mapping cache.
+    // If a recent execution for this meeting is still Running, refuse.
+    const subscriptionId = process.env.SUBSCRIPTION_ID;
+    const resourceGroup = process.env.CONTAINER_APP_JOB_RESOURCE_GROUP;
+    const jobName = process.env.CONTAINER_APP_JOB_NAME;
+
+    if (subscriptionId && resourceGroup && jobName) {
+      try {
+        const client = getContainerAppsClient(subscriptionId);
+        const cachedActive = findActiveExecutionForMeeting(
+          meetingId,
+          transcriptId,
+        );
+
+        if (cachedActive) {
+          // Verify it's actually still running via Azure (cache could be stale).
+          // SDK only exposes list() on jobsExecutions in this package version.
+          try {
+            let liveExec = null;
+            for await (const exec of client.jobsExecutions.list(
+              resourceGroup,
+              jobName,
+            )) {
+              if (exec.name === cachedActive.executionName) {
+                liveExec = exec;
+                break;
+              }
+            }
+            if (
+              liveExec &&
+              (liveExec.status === "Running" ||
+                liveExec.status === "Processing")
+            ) {
+              structuredLog(
+                context,
+                "info",
+                "Restart blocked: already running",
+                {
+                  meetingId,
+                  transcriptId,
+                  runningExecutionName: cachedActive.executionName,
+                  runningExecutionId: cachedActive.executionId,
+                  userId,
+                },
+              );
+              return createResponse(
+                request,
+                false,
+                "A processing run for this meeting is already in progress. Please wait for it to complete or cancel it before restarting.",
+                409,
+                { conflict: true },
+              );
+            }
+          } catch (liveCheckErr) {
+            // If the live check fails (e.g. execution was deleted), fall
+            // through. The cached entry was stale.
+            structuredLog(
+              context,
+              "warn",
+              "Live execution check failed, falling through",
+              {
+                executionName: cachedActive.executionName,
+                error: liveCheckErr.message,
+              },
+            );
+          }
+        }
+
+        // Cross-instance / cold-start fallback: cache may be empty, but Azure
+        // can still show a running execution for the same meeting.
+        for await (const exec of client.jobsExecutions.list(
+          resourceGroup,
+          jobName,
+        )) {
+          if (exec.status !== "Running" && exec.status !== "Processing") {
+            continue;
+          }
+          if (!executionMatchesMeeting(exec, meetingId, transcriptId)) {
+            continue;
+          }
+
+          structuredLog(
+            context,
+            "info",
+            "Restart blocked: live execution already running",
+            {
+              meetingId,
+              transcriptId,
+              runningExecutionName: exec.name,
+              userId,
+            },
+          );
+          return createResponse(
+            request,
+            false,
+            "A processing run for this meeting is already in progress. Please wait for it to complete or cancel it before restarting.",
+            409,
+            { conflict: true },
+          );
+        }
+      } catch (err) {
+        // Don't block restart on a check failure; log and proceed.
+        structuredLog(
+          context,
+          "warn",
+          "Layer 1 concurrency check failed, proceeding without it",
+          { error: err.message },
+        );
+      }
+    }
+
+    // Layer 2: in-process restart-in-flight set
+    if (isRestartInFlight(meetingId, transcriptId)) {
+      structuredLog(context, "info", "Restart blocked: in-flight", {
+        meetingId,
+        transcriptId,
+        userId,
+      });
+      return createResponse(
+        request,
+        false,
+        "A restart for this meeting was just requested. Please wait for it to start before trying again.",
+        409,
+        { conflict: true },
+      );
+    }
+
+    markRestartInFlight(meetingId, transcriptId);
+
+    // Re-enqueue the queue message. restartId lets ProcessTranscriptQueue
+    // dedup queue redelivery without blocking separate legitimate restarts.
+    const restartId = crypto.randomUUID();
+    const queueMessage = {
+      userId,
+      meetingId,
+      transcriptId,
+      skipSubjectFilter: true,
+      restartTrigger: true,
+      restartId,
+      restartedFromExecutionId: executionId,
+      restartedAt: new Date().toISOString(),
+    };
+
+    context.extraOutputs.set(queueOutput, [queueMessage]);
+
+    structuredLog(context, "info", "Restart enqueued", {
+      executionId,
+      meetingId,
+      transcriptId,
+      userId,
+      sourceIp,
+    });
+
+    return createResponse(
+      request,
+      true,
+      "Processing has been restarted. You'll receive a Teams notification when the new run begins.",
+      202,
+    );
+  },
+});

--- a/azure-function/src/functions/RestartProcessing.js
+++ b/azure-function/src/functions/RestartProcessing.js
@@ -6,6 +6,10 @@ const {
   structuredLog,
 } = require("./ProcessTranscriptQueue");
 
+const TIGER_LOGO_URL =
+  process.env.TIGER_LOGO_URL ||
+  "https://satigerstagingweb.blob.core.windows.net/assets/Logo.png";
+
 /**
  * HTTP trigger to restart a transcript processing job for the same meeting.
  * Called when the user clicks "Restart processing" on a "cancelled" or
@@ -83,7 +87,10 @@ function executionMatchesMeeting(execution, meetingId, transcriptId) {
 function generateHtmlResponse(success, message, details = {}) {
   // Three states: success (green), conflict (amber), error (red)
   const isConflict = details.conflict === true;
-  const icon = success ? "🐯" : isConflict ? "⏳" : "❌";
+  const icon = isConflict ? "⏳" : "❌";
+  const iconHtml = success
+    ? `<img src="${TIGER_LOGO_URL}" alt="" class="icon icon-img">`
+    : `<div class="icon">${icon}</div>`;
   const title = success
     ? "Restart Queued"
     : isConflict
@@ -117,7 +124,13 @@ function generateHtmlResponse(success, message, details = {}) {
       text-align: center;
       max-width: 400px;
     }
-    .icon { font-size: 64px; margin-bottom: 20px; }
+    .icon { font-size: 64px; line-height: 1; margin-bottom: 20px; }
+    .icon-img {
+      display: inline-block;
+      width: 64px;
+      height: 64px;
+      object-fit: contain;
+    }
     .title { font-size: 24px; font-weight: 600; margin-bottom: 12px; color: #333; }
     .message {
       padding: 16px;
@@ -132,7 +145,7 @@ function generateHtmlResponse(success, message, details = {}) {
 </head>
 <body>
   <div class="card">
-    <div class="icon">${icon}</div>
+    ${iconHtml}
     <div class="title">${title}</div>
     <div class="message">${message}</div>
     <div class="close-hint">You can close this window now.</div>

--- a/azure-function/src/functions/RestartProcessing.js
+++ b/azure-function/src/functions/RestartProcessing.js
@@ -177,13 +177,17 @@ function createResponse(request, success, message, statusCode, details = {}) {
 function generateConfirmationResponse(request) {
   return {
     status: 200,
-    headers: { "Content-Type": "text/html" },
+    headers: {
+      "Content-Type": "text/html",
+      "Cache-Control": "no-store",
+      "X-Robots-Tag": "noindex, nofollow",
+    },
     body: `<!DOCTYPE html>
 <html>
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Restart Processing - SSW Tiger</title>
+  <title>Re-run Analysis</title>
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -193,6 +197,7 @@ function generateConfirmationResponse(request) {
       min-height: 100vh;
       margin: 0;
       background: #f5f5f5;
+      color: #333;
     }
     .card {
       background: white;
@@ -200,42 +205,31 @@ function generateConfirmationResponse(request) {
       box-shadow: 0 4px 20px rgba(0,0,0,0.1);
       padding: 40px;
       text-align: center;
-      max-width: 400px;
+      max-width: 420px;
     }
-    .icon { font-size: 64px; margin-bottom: 20px; }
-    .title { font-size: 24px; font-weight: 600; margin-bottom: 12px; color: #333; }
-    .message {
-      padding: 16px;
+    .title { font-size: 24px; font-weight: 600; margin-bottom: 12px; }
+    .message { color: #555; line-height: 1.5; margin-bottom: 24px; }
+    .keep-hint { color: #777; font-size: 14px; margin-bottom: 16px; }
+    button {
       border-radius: 8px;
-      background: #fff3cd;
-      color: #856404;
-      border: 1px solid #ffeaa7;
-      margin-bottom: 20px;
-    }
-    .action-button {
-      display: inline-block;
-      margin-top: 8px;
-      padding: 12px 24px;
-      background: #cc0000;
-      color: white;
-      border: none;
-      border-radius: 6px;
-      font-size: 16px;
+      border: 0;
+      padding: 12px 18px;
+      font: inherit;
       font-weight: 600;
       cursor: pointer;
+      background: #CC4141;
+      color: white;
     }
-    .close-hint { margin-top: 20px; color: #999; font-size: 14px; }
   </style>
 </head>
 <body>
   <div class="card">
-    <div class="icon">↻</div>
-    <div class="title">Restart Processing?</div>
-    <div class="message">This will re-run the meeting analysis from scratch.</div>
+    <div class="title">Re-run this meeting analysis?</div>
+    <div class="message">The previous results will be replaced. A full re-analysis will run and you'll receive a new Teams notification when it's ready.</div>
     <form method="POST" action="${request.url}">
-      <button type="submit" class="action-button">↻ Confirm Restart</button>
+      <button type="submit">Re-run Analysis</button>
     </form>
-    <div class="close-hint">You can close this window if you do not want to restart.</div>
+    <div class="keep-hint">To keep the existing results, close this tab.</div>
   </div>
 </body>
 </html>`,
@@ -289,17 +283,18 @@ app.http("RestartProcessing", {
 
     // Teams and security scanners can prefetch links with GET. GET must be
     // side-effect free; only the confirmation form's POST may enqueue a run.
-    if (request.method === "GET") {
-      return generateConfirmationResponse(request);
-    }
-
-    // Layer 1: Live check via Container Apps API + in-memory mapping cache.
-    // If a recent execution for this meeting is still Running, refuse.
+    // However, we do a live running-check on GET so the user sees "Already
+    // Running" immediately instead of hitting it after clicking confirm.
     const subscriptionId = process.env.SUBSCRIPTION_ID;
     const resourceGroup = process.env.CONTAINER_APP_JOB_RESOURCE_GROUP;
     const jobName = process.env.CONTAINER_APP_JOB_NAME;
 
-    if (subscriptionId && resourceGroup && jobName) {
+    /**
+     * Check whether a job for this meeting is already running.
+     * Returns true if a running execution was found (and logs it).
+     */
+    async function isAlreadyRunning() {
+      if (!subscriptionId || !resourceGroup || !jobName) return false;
       try {
         const client = getContainerAppsClient(subscriptionId);
         const cachedActive = findActiveExecutionForMeeting(
@@ -308,8 +303,6 @@ app.http("RestartProcessing", {
         );
 
         if (cachedActive) {
-          // Verify it's actually still running via Azure (cache could be stale).
-          // SDK only exposes list() on jobsExecutions in this package version.
           try {
             let liveExec = null;
             for await (const exec of client.jobsExecutions.list(
@@ -326,29 +319,14 @@ app.http("RestartProcessing", {
               (liveExec.status === "Running" ||
                 liveExec.status === "Processing")
             ) {
-              structuredLog(
-                context,
-                "info",
-                "Restart blocked: already running",
-                {
-                  meetingId,
-                  transcriptId,
-                  runningExecutionName: cachedActive.executionName,
-                  runningExecutionId: cachedActive.executionId,
-                  userId,
-                },
-              );
-              return createResponse(
-                request,
-                false,
-                "A processing run for this meeting is already in progress. Please wait for it to complete or cancel it before restarting.",
-                409,
-                { conflict: true },
-              );
+              structuredLog(context, "info", "Already running (cache hit)", {
+                meetingId,
+                transcriptId,
+                runningExecutionName: cachedActive.executionName,
+              });
+              return true;
             }
           } catch (liveCheckErr) {
-            // If the live check fails (e.g. execution was deleted), fall
-            // through. The cached entry was stale.
             structuredLog(
               context,
               "warn",
@@ -361,8 +339,7 @@ app.http("RestartProcessing", {
           }
         }
 
-        // Cross-instance / cold-start fallback: cache may be empty, but Azure
-        // can still show a running execution for the same meeting.
+        // Cross-instance / cold-start fallback
         for await (const exec of client.jobsExecutions.list(
           resourceGroup,
           jobName,
@@ -373,35 +350,62 @@ app.http("RestartProcessing", {
           if (!executionMatchesMeeting(exec, meetingId, transcriptId)) {
             continue;
           }
-
-          structuredLog(
-            context,
-            "info",
-            "Restart blocked: live execution already running",
-            {
-              meetingId,
-              transcriptId,
-              runningExecutionName: exec.name,
-              userId,
-            },
-          );
-          return createResponse(
-            request,
-            false,
-            "A processing run for this meeting is already in progress. Please wait for it to complete or cancel it before restarting.",
-            409,
-            { conflict: true },
-          );
+          structuredLog(context, "info", "Already running (live API scan)", {
+            meetingId,
+            transcriptId,
+            runningExecutionName: exec.name,
+          });
+          return true;
         }
       } catch (err) {
-        // Don't block restart on a check failure; log and proceed.
         structuredLog(
           context,
           "warn",
-          "Layer 1 concurrency check failed, proceeding without it",
+          "Running-check failed, assuming not running",
           { error: err.message },
         );
       }
+      return false;
+    }
+
+    if (request.method === "GET") {
+      if (await isAlreadyRunning()) {
+        structuredLog(
+          context,
+          "info",
+          "GET: already running, showing conflict page",
+          {
+            meetingId,
+            transcriptId,
+            userId,
+          },
+        );
+        return createResponse(
+          request,
+          false,
+          "A processing run for this meeting is already in progress. Please wait for it to complete or cancel it before restarting.",
+          409,
+          { conflict: true },
+        );
+      }
+      return generateConfirmationResponse(request);
+    }
+
+    // POST: repeat the check (user may have left the confirm page open while
+    // a new run was triggered by someone else, or via a double-click race).
+    if (await isAlreadyRunning()) {
+      structuredLog(context, "info", "Restart blocked: already running", {
+        meetingId,
+        transcriptId,
+        userId,
+      });
+      return createResponse(
+        request,
+        false,
+        "A processing run for this meeting is already in progress. Please wait for it to complete or cancel it before restarting.",
+        409,
+        { conflict: true },
+      );
     }
 
     // Layer 2: in-process restart-in-flight set

--- a/azure-function/src/functions/RestartProcessing.js
+++ b/azure-function/src/functions/RestartProcessing.js
@@ -13,13 +13,15 @@ const TIGER_LOGO_URL =
 /**
  * HTTP trigger to restart a transcript processing job for the same meeting.
  * Called when the user clicks "Restart processing" on a "cancelled" or
- * "failed" Teams card, or on the cancel-success HTML page.
+ * "failed" Teams card.
  *
  * Query parameters:
  *   - executionId   : original execution ID (for audit/correlation; pseudo-token)
  *   - userId        : Graph user ID of the meeting organizer
  *   - meetingId     : Graph meeting ID
  *   - transcriptId  : Graph transcript ID
+ *   - expiresAt     : token expiry timestamp in milliseconds
+ *   - token         : HMAC signature for the restart request
  *
  * Concurrency defence:
  *   1. List Container App Job executions and check if one is already running
@@ -27,7 +29,7 @@ const TIGER_LOGO_URL =
  *   2. In-process restart-in-flight set blocks rapid double-clicks within the
  *      window between this endpoint and ProcessTranscriptQueue picking up the
  *      message.
- *   3. ProcessTranscriptQueue has its own dedup keyed by `restart-${meetingId}-${transcriptId}`.
+ *   3. ProcessTranscriptQueue dedups Azure Queue redelivery by restartId.
  */
 
 // In-memory tracking of restart requests issued in the last 30 seconds.
@@ -84,12 +86,78 @@ function executionMatchesMeeting(execution, meetingId, transcriptId) {
   return false;
 }
 
+function escapeHtml(value = "") {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function getRestartTokenSecret() {
+  return (
+    process.env.RESTART_TOKEN_SECRET ||
+    process.env.WEBHOOK_CLIENT_STATE ||
+    process.env.GRAPH_CLIENT_SECRET
+  );
+}
+
+function createRestartSignature({
+  executionId,
+  userId,
+  meetingId,
+  transcriptId,
+  expiresAt,
+}) {
+  const secret = getRestartTokenSecret();
+  if (!secret) return "";
+
+  return crypto
+    .createHmac("sha256", secret)
+    .update(
+      [executionId, userId, meetingId, transcriptId, String(expiresAt)].join(
+        "|",
+      ),
+    )
+    .digest("hex");
+}
+
+function isValidRestartToken({
+  executionId,
+  userId,
+  meetingId,
+  transcriptId,
+  expiresAt,
+  token,
+}) {
+  if (!token || !expiresAt) return false;
+
+  const expiry = Number(expiresAt);
+  if (!Number.isFinite(expiry) || expiry <= Date.now()) {
+    return false;
+  }
+
+  const expected = createRestartSignature({
+    executionId,
+    userId,
+    meetingId,
+    transcriptId,
+    expiresAt,
+  });
+  if (!expected || expected.length !== token.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(token));
+}
+
 function generateHtmlResponse(success, message, details = {}) {
   // Three states: success (green), conflict (amber), error (red)
   const isConflict = details.conflict === true;
   const icon = isConflict ? "⏳" : "❌";
   const iconHtml = success
-    ? `<img src="${TIGER_LOGO_URL}" alt="" class="icon icon-img">`
+    ? `<img src="${escapeHtml(TIGER_LOGO_URL)}" alt="" class="icon icon-img">`
     : `<div class="icon">${icon}</div>`;
   const title = success
     ? "Restart Queued"
@@ -105,7 +173,7 @@ function generateHtmlResponse(success, message, details = {}) {
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>${title} - SSW Tiger</title>
+  <title>${escapeHtml(title)} - SSW Tiger</title>
   <style>
     body {
       font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
@@ -146,8 +214,8 @@ function generateHtmlResponse(success, message, details = {}) {
 <body>
   <div class="card">
     ${iconHtml}
-    <div class="title">${title}</div>
-    <div class="message">${message}</div>
+    <div class="title">${escapeHtml(title)}</div>
+    <div class="message">${escapeHtml(message)}</div>
     <div class="close-hint">You can close this window now.</div>
   </div>
 </body>
@@ -175,6 +243,8 @@ function createResponse(request, success, message, statusCode, details = {}) {
 }
 
 function generateConfirmationResponse(request) {
+  const formAction = escapeHtml(request.url);
+
   return {
     status: 200,
     headers: {
@@ -226,7 +296,7 @@ function generateConfirmationResponse(request) {
   <div class="card">
     <div class="title">Re-run this meeting analysis?</div>
     <div class="message">The previous results will be replaced. A full re-analysis will run and you'll receive a new Teams notification when it's ready.</div>
-    <form method="POST" action="${request.url}">
+    <form method="POST" action="${formAction}">
       <button type="submit">Re-run Analysis</button>
     </form>
     <div class="keep-hint">To keep the existing results, close this tab.</div>
@@ -251,6 +321,8 @@ app.http("RestartProcessing", {
     const userId = request.query.get("userId");
     const meetingId = request.query.get("meetingId");
     const transcriptId = request.query.get("transcriptId");
+    const expiresAt = request.query.get("expiresAt");
+    const token = request.query.get("token");
     const sourceIp =
       request.headers.get("x-forwarded-for") ||
       request.headers.get("x-azure-clientip") ||
@@ -271,6 +343,8 @@ app.http("RestartProcessing", {
     if (!userId) missing.push("userId");
     if (!meetingId) missing.push("meetingId");
     if (!transcriptId) missing.push("transcriptId");
+    if (!expiresAt) missing.push("expiresAt");
+    if (!token) missing.push("token");
 
     if (missing.length > 0) {
       return createResponse(
@@ -278,6 +352,31 @@ app.http("RestartProcessing", {
         false,
         `Missing required parameter(s): ${missing.join(", ")}`,
         400,
+      );
+    }
+
+    if (
+      !isValidRestartToken({
+        executionId,
+        userId,
+        meetingId,
+        transcriptId,
+        expiresAt,
+        token,
+      })
+    ) {
+      structuredLog(context, "warn", "Restart rejected: invalid token", {
+        executionId,
+        meetingId,
+        transcriptId,
+        userId,
+        sourceIp,
+      });
+      return createResponse(
+        request,
+        false,
+        "This restart link is invalid or has expired. Please use the latest Teams notification link.",
+        403,
       );
     }
 
@@ -290,11 +389,13 @@ app.http("RestartProcessing", {
     const jobName = process.env.CONTAINER_APP_JOB_NAME;
 
     /**
-     * Check whether a job for this meeting is already running.
-     * Returns true if a running execution was found (and logs it).
+     * Check whether a job for this meeting is already running. Returns:
+     * - true: running execution found
+     * - false: no running execution found
+     * - null: status unknown because config/API lookup failed
      */
-    async function isAlreadyRunning() {
-      if (!subscriptionId || !resourceGroup || !jobName) return false;
+    async function checkAlreadyRunning() {
+      if (!subscriptionId || !resourceGroup || !jobName) return null;
       try {
         const client = getContainerAppsClient(subscriptionId);
         const cachedActive = findActiveExecutionForMeeting(
@@ -361,15 +462,25 @@ app.http("RestartProcessing", {
         structuredLog(
           context,
           "warn",
-          "Running-check failed, assuming not running",
+          "Running-check failed",
           { error: err.message },
         );
+        return null;
       }
       return false;
     }
 
     if (request.method === "GET") {
-      if (await isAlreadyRunning()) {
+      const runningStatus = await checkAlreadyRunning();
+      if (runningStatus === null) {
+        return createResponse(
+          request,
+          false,
+          "Restart status is temporarily unavailable. Please try again in a minute.",
+          503,
+        );
+      }
+      if (runningStatus) {
         structuredLog(
           context,
           "info",
@@ -393,7 +504,16 @@ app.http("RestartProcessing", {
 
     // POST: repeat the check (user may have left the confirm page open while
     // a new run was triggered by someone else, or via a double-click race).
-    if (await isAlreadyRunning()) {
+    const runningStatus = await checkAlreadyRunning();
+    if (runningStatus === null) {
+      return createResponse(
+        request,
+        false,
+        "Restart status is temporarily unavailable. Please try again in a minute.",
+        503,
+      );
+    }
+    if (runningStatus) {
       structuredLog(context, "info", "Restart blocked: already running", {
         meetingId,
         transcriptId,

--- a/azure-function/src/functions/TriggerProcessing.js
+++ b/azure-function/src/functions/TriggerProcessing.js
@@ -18,11 +18,17 @@ const { app, output } = require("@azure/functions");
 
 const LOG_PREFIX = "[TIGER]";
 
+const TIGER_LOGO_URL =
+  process.env.TIGER_LOGO_URL ||
+  "https://satigerstagingweb.blob.core.windows.net/assets/Logo.png";
+
 /**
  * Generate HTML response page for browser requests
  */
 function generateHtmlResponse(success, message, details = {}) {
-  const icon = success ? "🐯" : "❌";
+  const iconHtml = success
+    ? `<img src="${TIGER_LOGO_URL}" alt="" class="icon icon-img">`
+    : `<div class="icon">❌</div>`;
   const title = success ? "Processing Queued" : "Trigger Failed";
   const bgColor = success ? "#d4edda" : "#f8d7da";
   const textColor = success ? "#155724" : "#721c24";
@@ -59,7 +65,13 @@ function generateHtmlResponse(success, message, details = {}) {
       text-align: center;
       max-width: 400px;
     }
-    .icon { font-size: 64px; margin-bottom: 20px; }
+    .icon { font-size: 64px; line-height: 1; margin-bottom: 20px; }
+    .icon-img {
+      display: inline-block;
+      width: 64px;
+      height: 64px;
+      object-fit: contain;
+    }
     .title { font-size: 24px; font-weight: 600; margin-bottom: 12px; color: #333; }
     .message {
       padding: 16px;
@@ -76,7 +88,7 @@ function generateHtmlResponse(success, message, details = {}) {
 </head>
 <body>
   <div class="card">
-    <div class="icon">${icon}</div>
+    ${iconHtml}
     <div class="title">${title}</div>
     <div class="message">${message}</div>
     ${detailsHtml}

--- a/azure-function/src/functions/index.js
+++ b/azure-function/src/functions/index.js
@@ -4,3 +4,4 @@ require("./ProcessTranscriptQueue");
 require("./RenewSubscription");
 require("./CancelProcessing");
 require("./TriggerProcessing");
+require("./RestartProcessing");

--- a/processor/sendNotification.js
+++ b/processor/sendNotification.js
@@ -36,6 +36,7 @@ const CONFIG = {
   cancelUrl: process.env.CANCEL_URL, // URL to cancel processing (for "started" notifications)
   executionId: process.env.JOB_EXECUTION_ID, // Execution ID for tracking
   triggerUrl: process.env.TRIGGER_URL, // URL to manually trigger processing (for "skipped" notifications)
+  restartUrl: process.env.RESTART_URL, // URL to restart processing (for "cancelled" and "failed" notifications)
   meetingDuration: process.env.MEETING_DURATION || null, // Pre-formatted duration string (e.g. "23 min", "1 hr 32 min")
 };
 
@@ -86,6 +87,21 @@ async function sendViaLogicApp(participants) {
     payload.triggerUrl = CONFIG.triggerUrl;
     log("debug", "Including trigger URL in notification", {
       triggerUrl: CONFIG.triggerUrl,
+    });
+  }
+
+  // Include restartUrl for "cancelled" and "failed" notifications
+  // (allows any participant to re-run the pipeline for the same meeting)
+  if (
+    (CONFIG.notificationType === "cancelled" ||
+      CONFIG.notificationType === "failed") &&
+    CONFIG.restartUrl
+  ) {
+    payload.restartUrl = CONFIG.restartUrl;
+    payload.executionId = CONFIG.executionId;
+    log("debug", "Including restart URL in notification", {
+      restartUrl: CONFIG.restartUrl,
+      executionId: CONFIG.executionId,
     });
   }
 


### PR DESCRIPTION
## What changed

- Added a `RestartProcessing` Azure Function endpoint for restarting failed or cancelled transcript processing runs.
- Added restart metadata to `ProcessTranscriptQueue` so restart-triggered jobs bypass normal webhook/manual dedup safely.
- Added `RESTART_URL` to the Container App Job environment.
- Added restart URL support to failed/cancelled Teams notification payloads.
- Registered the new restart function in `azure-function/src/functions/index.js`.
- Replaced the tiger emoji with the Tiger logo on the restart and trigger browser response pages.

## Why

See #100.  This lets users restart a failed or cancelled processing job directly from the Teams notification card, without touching the cancel flow or changing container entrypoint behavior.
