### PR TITLE
✨ Tiger - Adding project prefix before key decisions, items done this Sprint, next steps, and action items

### DIFF
--- a/.claude/agents/analytics-generator.md
+++ b/.claude/agents/analytics-generator.md
@@ -294,6 +294,10 @@ Where optimal = minimum time needed for same outcomes
 }
 ```
 
+### Item product prefix (applies to any `actionItems[]` you emit)
+
+Every action item string must begin with `<Product> - ` followed by the description. Use the **short** product name: `Cheetah` not `SSW.Cheetah`, `Crystal Ball` not `SSW.CrystalBall`, `Tiger` not `SSW.Tiger`. Use `General` when no specific product applies; never omit the prefix. See the full rule in `consolidator.md` > `Item product prefix`.
+
 ## Your Standards
 
 - **Brutal accuracy over comfortable approximation**

--- a/.claude/agents/consolidator.md
+++ b/.claude/agents/consolidator.md
@@ -489,6 +489,20 @@ Note what's missing:
 }
 ```
 
+### Item product prefix (applies to `keyDecisions.items[]`, `doneThisSprint.items[]`, `nextSteps.items[]`, `actionItems[]`)
+
+Every item string emitted in these four fields - including action items nested inside timeline segments - must begin with the **short** name of the product or project the item is associated with, followed by ` - ` (space, hyphen, space), followed by the description you would have written anyway.
+
+Format: `<Product> - <description>`
+
+Rules (each shown as right-form not wrong-form):
+
+- **Short name, not fully-qualified.** `Cheetah` not `SSW.Cheetah`, `Crystal Ball` not `SSW.CrystalBall`, `Tiger` not `SSW.Tiger`, `YakShaver` not `SSW.YakShaver`.
+- **Multi-word product names stay multi-word.** `Crystal Ball - ...` not `CrystalBall - ...`.
+- **No-product fallback is `General`.** `General - Updated contribution guide for new joiners` not `Misc - ...`, not `Other - ...`, not an item with no prefix at all.
+- **Cross-cutting items pick the primary product.** `Cheetah - Updated shared auth flow` not `Cheetah/Crystal Ball - ...` and not `Multiple - ...`.
+- **The prefix is prepended; the rest is unchanged.** `Cheetah - Shipped onboarding flow redesign (Alice)` not `Shipped onboarding flow redesign (Alice)`. The trailing `(owner)` annotation is preserved as-is.
+
 ## Your Standards
 
 - **Consistency is non-negotiable** - Names, numbers, ratings must align

--- a/.claude/agents/longitudinal-analyzer.md
+++ b/.claude/agents/longitudinal-analyzer.md
@@ -334,6 +334,10 @@ Answer honestly based on the data:
 }
 ```
 
+### Item product prefix (applies to any `actionItems[]` you emit)
+
+Every action item string must begin with `<Product> - ` followed by the description. Use the **short** product name: `Cheetah` not `SSW.Cheetah`, `Crystal Ball` not `SSW.CrystalBall`, `Tiger` not `SSW.Tiger`. Use `General` when no specific product applies; never omit the prefix. See the full rule in `consolidator.md` > `Item product prefix`.
+
 ## If No Historical Data
 
 ```json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,9 +203,9 @@ Any color NOT in this table is **forbidden** as a background. This means no `bg-
 All sections below use `<li>` bullet points inside `<ul>` — consistent style throughout.
 
 - **Meeting Summary** — **brief** factual bullet points, max 5 bullets. Each bullet is one short sentence. No commentary or analysis. Example: `<li>Sprint 98 delivered 35 points across 12 PBIs</li>`
-- **Key Decisions** — choices between alternatives, **max 3 bullets** (e.g., "Use SSW Identity Server instead of building from scratch"). Sprint goal setting is NOT a key decision — it belongs in the summary.
-- **Done This Sprint** — outcomes, features completed/demoed, issues resolved. Each item as a plain `<li>` with owner in parentheses. No emoji icons. Do NOT repeat decisions already in Key Decisions.
-- **Next Steps** — work items for next sprint and other follow-up actions, as plain `<li>` bullets with owner **(canonical names!)**. No emoji icons.
+- **Key Decisions** — choices between alternatives, **max 3 bullets** (e.g., "Use SSW Identity Server instead of building from scratch"). Sprint goal setting is NOT a key decision — it belongs in the summary. Each bullet starts with `<Product> - ` (see `consolidator.md` > `Item product prefix`).
+- **Done This Sprint** — outcomes, features completed/demoed, issues resolved. Each item as a plain `<li>` with owner in parentheses. No emoji icons. Do NOT repeat decisions already in Key Decisions. Each bullet starts with `<Product> - ` (see `consolidator.md` > `Item product prefix`).
+- **Next Steps** — work items for next sprint and other follow-up actions, as plain `<li>` bullets with owner **(canonical names!)**. No emoji icons. Each bullet starts with `<Product> - ` (see `consolidator.md` > `Item product prefix`).
 - **Hard truths** — **MAX 2 items, each max 2 sentences.** Keep them punchy and direct, not paragraph-length essays. ONLY high-level synthesis that genuinely doesn't fit in Insights, People, or Trends.
 
 ### Tab 2: Timeline


### PR DESCRIPTION
## 📝 Summary of Changes

Added an **Item product prefix** rule that requires every bullet in `keyDecisions.items[]`, `doneThisSprint.items[]`, `nextSteps.items[]`, and `actionItems[]` (wherever it appears) to begin with `<Product> - ` followed by the description the agent would have written anyway.

- **Canonical rule** sits in `.claude/agents/consolidator.md` next to the output-format schema. The consolidator owns 3 of those 4 fields outright and is the agent that composes the prose, so the rule lives next to where it's enforced.
- **Mirrored 3-line pointers** in `.claude/agents/analytics-generator.md` and `.claude/agents/longitudinal-analyzer.md` cover their independent `actionItems[]` outputs.
- **One-line pointers** appended to the Key Decisions / Done This Sprint / Next Steps bullets in `CLAUDE.md` > Tab 1: Overview, so the format is discoverable from `CLAUDE.md` without duplicating the rule body.

### 🤷‍♂️ Why

When items from multiple products land in the same dashboard (e.g. an SSW AI sprint review touching Cheetah, Crystal Ball, Tiger, YakShaver, SophieClaw), the bullets become hard to scan because there's no quick way to see which product each line belongs to. Prefixing every bullet with the product name fixes that with zero UI work - purely a prompt-eng change. Short product names only (`Cheetah`, `Crystal Ball`, `Tiger`), `General` as the fallback for items with no clear product, primary-product wins for cross-cutting items. Closes #107.

🤖 Generated with [Claude Code](https://claude.com/claude-code)