### PR TITLE
Show weekday prefix on dashboard date (e.g. Mon 25/05/2026)

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -233,7 +233,7 @@
                     </div>
                 </div>
                 <div class="text-right">
-                    <p class="text-2xl font-bold text-ssw-red">{{DATE}}</p>
+                    <p class="text-2xl font-bold text-ssw-red"><span class="js-meeting-date">{{DATE}}</span></p>
                     <p class="text-sm text-ssw-gray-500 font-medium">{{MEETING_TYPE}} • {{DURATION}}</p>
                 </div>
             </div>
@@ -503,6 +503,20 @@
         
         Chart.defaults.font.family = "'Inter', 'Helvetica Neue', 'Helvetica', sans-serif";
         Chart.defaults.color = '#333333';
+
+        // Prefix the meeting date with a 3-letter weekday (e.g. "25/05/2026" -> "Mon 25/05/2026").
+        // Date format is DD/MM/YYYY per CLAUDE.md; if parsing fails the original text stays untouched.
+        document.querySelectorAll('.js-meeting-date').forEach(function (el) {
+            var match = (el.textContent || '').trim().match(/^(\d{1,2})\/(\d{1,2})\/(\d{4})$/);
+            if (!match) return;
+            var day = parseInt(match[1], 10);
+            var month = parseInt(match[2], 10) - 1;
+            var year = parseInt(match[3], 10);
+            var d = new Date(year, month, day);
+            if (isNaN(d.getTime())) return;
+            var weekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+            el.textContent = weekdays[d.getDay()] + ' ' + el.textContent;
+        });
 
         // Handle profile image load failures - falls back to initials
         // The initials MUST come from trusted participant data (canonical names)


### PR DESCRIPTION
Corresponding issue: #122
## 📝 Summary of Changes

- Meeting date in the dashboard top bar now leads with a 3-letter weekday, e.g. `Mon 25/05/2026` instead of `25/05/2026`.

### 🤷‍♂️ Why
Knowing the day of the week at a glance makes it easier to orient yourself when scanning past dashboards (especially when the project name and date are the only header info). Computed client-side from the existing `DD/MM/YYYY` date so the prefix is always correct and we don't have to rely on the model getting the weekday right.

### 🧪 Test plan
- [x] Verified the weekday calculation on a few sample dates (25/05/2026 -> Mon, 01/01/2026 -> Thu, 31/12/2025 -> Wed)
- [x] Open a freshly generated dashboard and confirm the date in the top right reads `<Day> DD/MM/YYYY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)