### PR TITLE
Always overwrite tailwind.config block instead of detect-and-repair

### DIFF
--- a/processor/dashboardValidator.js
+++ b/processor/dashboardValidator.js
@@ -71,9 +71,14 @@ function findSyntaxError(body) {
 }
 
 /**
- * Unconditionally replace the dashboard's `tailwind.config` <script>
- * block with the canonical one from the template. Writes the file only
- * if the block actually differed.
+ * Overwrite the dashboard's `tailwind.config` <script> block with the
+ * canonical one from the template, unconditionally. Whatever the model
+ * emitted for that block is discarded. Writes the file only when the
+ * block actually differs from canonical (no spurious churn).
+ *
+ * Despite the name, this function no longer "validates" or "repairs"
+ * conditionally - it stamps. The name is preserved for call-site
+ * compatibility with processor/index.js.
  *
  * Also parse-checks every other inline script and logs a warning if any
  * fail (non-fatal - we cannot auto-repair those).

--- a/processor/dashboardValidator.js
+++ b/processor/dashboardValidator.js
@@ -1,22 +1,24 @@
 /**
  * Dashboard Validator & Repair
  *
- * Guard against LLM-generated syntax errors in the dashboard's inline
- * <script> blocks. The Tailwind config block is the highest-blast-radius
- * target: a single typo there throws a SyntaxError, the entire
- * `tailwind.config = {...}` assignment never runs, and every utility
- * built on the custom palette (`ssw-red`, `ssw-charcoal`, `ssw-gray`)
- * silently produces no CSS — leaving the dashboard mostly black-and-white
- * with invisible text.
+ * The dashboard's inline `tailwind.config` <script> block is pure static
+ * styling configuration (SSW colour palettes + font stack) with no
+ * per-meeting data. The model has no business regenerating it from
+ * scratch, but it does, and every regeneration is a chance to introduce
+ * a typo that breaks the whole palette and leaves the dashboard mostly
+ * black-and-white with invisible text (see GitHub issue #98).
  *
- * After the model writes the dashboard HTML, this module:
- *   1. Extracts every inline <script> block.
- *   2. Parses each via `new Function(body)` to surface SyntaxErrors
- *      without executing the code.
- *   3. If any block fails to parse, replaces the corrupted
- *      `tailwind.config` block with the canonical version from
- *      templates/dashboard.html.
- *   4. Re-validates after repair and writes the fixed file.
+ * Rather than detect-and-repair (PR #99's approach, which only catches
+ * SyntaxErrors and missed runtime ReferenceErrors like an unquoted
+ * `sans-serif` parsing as `sans - serif`), this module unconditionally
+ * overwrites the dashboard's `tailwind.config` block with the canonical
+ * one from templates/dashboard.html. Whatever the model emitted for
+ * that block is discarded.
+ *
+ * Other inline scripts (chart setup, profile-image fallback) are
+ * parse-checked as a non-fatal diagnostic only - we have no canonical
+ * version to stamp in for those, so we just log a warning if any of
+ * them fail to parse.
  */
 
 const fs = require("fs").promises;
@@ -55,10 +57,9 @@ function findTailwindConfigScript(html) {
 }
 
 /**
- * Try to parse a script body as a function body. Returns the SyntaxError
- * (or other Error) if parsing fails, otherwise null. `new Function` only
- * parses the body; it does not execute it, so undefined free variables
- * (like `tailwind`) do not trigger a runtime error here.
+ * Parse-check a script body via `new Function`. Returns the error if
+ * parsing fails, null otherwise. Used as a non-fatal diagnostic for
+ * non-tailwind inline scripts.
  */
 function findSyntaxError(body) {
   try {
@@ -70,10 +71,12 @@ function findSyntaxError(body) {
 }
 
 /**
- * Validate the dashboard's inline scripts. If any block has a syntax
- * error, repair by replacing the canonical `tailwind.config` block from
- * the template (which is the only block known to be a recurring
- * regeneration target). Writes the file back if repaired.
+ * Unconditionally replace the dashboard's `tailwind.config` <script>
+ * block with the canonical one from the template. Writes the file only
+ * if the block actually differed.
+ *
+ * Also parse-checks every other inline script and logs a warning if any
+ * fail (non-fatal - we cannot auto-repair those).
  *
  * @param {string} dashboardPath - absolute path to dashboard HTML
  * @param {string} templatePath - absolute path to templates/dashboard.html
@@ -81,65 +84,57 @@ function findSyntaxError(body) {
  */
 async function validateAndRepairDashboard(dashboardPath, templatePath) {
   const html = await fs.readFile(dashboardPath, "utf8");
-  const scripts = extractInlineScripts(html);
 
-  const failures = scripts
-    .map((s) => ({ ...s, error: findSyntaxError(s.body) }))
-    .filter((s) => s.error);
-
-  if (failures.length === 0) {
-    log("debug", "Dashboard inline scripts all parse cleanly", {
-      scriptCount: scripts.length,
-    });
-    return { ok: true, repaired: false };
-  }
-
-  log("warn", "Dashboard inline <script> has syntax error(s) - attempting repair", {
-    failureCount: failures.length,
-    firstError: failures[0].error.message,
-  });
-
-  const dashboardTailwindBlock = findTailwindConfigScript(html);
-  if (!dashboardTailwindBlock) {
-    log("warn", "Dashboard has no tailwind.config block to repair");
-    return { ok: false, repaired: false, reason: "no-matching-block-in-dashboard" };
+  const dashboardBlock = findTailwindConfigScript(html);
+  if (!dashboardBlock) {
+    log("warn", "Dashboard has no tailwind.config block - cannot stamp canonical version");
+    return { ok: false, repaired: false, reason: "no-tailwind-block-in-dashboard" };
   }
 
   const template = await fs.readFile(templatePath, "utf8");
   const canonicalBlock = findTailwindConfigScript(template);
   if (!canonicalBlock) {
-    log("warn", "Could not locate canonical tailwind.config block in template - skipping repair");
+    log("warn", "Template has no tailwind.config block - skipping repair");
     return { ok: false, repaired: false, reason: "template-block-not-found" };
   }
 
-  const corruptedBlockSyntaxError = findSyntaxError(dashboardTailwindBlock.body);
-  if (!corruptedBlockSyntaxError) {
-    log("warn", "Dashboard tailwind.config block parses cleanly; corruption is elsewhere - cannot auto-repair");
-    return { ok: false, repaired: false, reason: "corruption-outside-tailwind-block" };
+  const blocksMatch = dashboardBlock.full === canonicalBlock.full;
+
+  if (!blocksMatch) {
+    const repairedHtml =
+      html.slice(0, dashboardBlock.index) +
+      canonicalBlock.full +
+      html.slice(dashboardBlock.index + dashboardBlock.full.length);
+    await fs.writeFile(dashboardPath, repairedHtml);
+    log("info", "Dashboard tailwind.config block overwritten with canonical version", {
+      dashboardPath,
+    });
+    warnOnOtherScriptParseFailures(repairedHtml);
+    return { ok: true, repaired: true };
   }
 
-  const repaired =
-    html.slice(0, dashboardTailwindBlock.index) +
-    canonicalBlock.full +
-    html.slice(dashboardTailwindBlock.index + dashboardTailwindBlock.full.length);
+  warnOnOtherScriptParseFailures(html);
+  return { ok: true, repaired: false };
+}
 
-  const remainingFailures = extractInlineScripts(repaired)
+/**
+ * Parse-check every inline script *except* the tailwind.config block
+ * (which is now canonical by construction). Logs a warning if any
+ * fail - non-fatal, since we have no canonical version to stamp in
+ * for those.
+ */
+function warnOnOtherScriptParseFailures(html) {
+  const failures = extractInlineScripts(html)
+    .filter((s) => !TAILWIND_CONFIG_MARKER.test(s.body))
     .map((s) => ({ ...s, error: findSyntaxError(s.body) }))
     .filter((s) => s.error);
 
-  if (remainingFailures.length > 0) {
-    log("warn", "Repair did not eliminate all syntax errors", {
-      remaining: remainingFailures.length,
-      firstError: remainingFailures[0].error.message,
+  if (failures.length > 0) {
+    log("warn", "Non-tailwind inline <script>(s) failed to parse - cannot auto-repair", {
+      failureCount: failures.length,
+      firstError: failures[0].error.message,
     });
-    return { ok: false, repaired: false, reason: "repair-incomplete" };
   }
-
-  await fs.writeFile(dashboardPath, repaired);
-  log("info", "Dashboard tailwind.config block repaired from template", {
-    dashboardPath,
-  });
-  return { ok: true, repaired: true };
 }
 
 module.exports = {

--- a/processor/dashboardValidator.test.js
+++ b/processor/dashboardValidator.test.js
@@ -145,6 +145,20 @@ describe("findSyntaxError", () => {
   });
 });
 
+describe("templates/dashboard.html canonical block", () => {
+  it("parses cleanly - this is the source of truth the validator stamps in", async () => {
+    const templatePath = path.join(__dirname, "..", "templates", "dashboard.html");
+    const template = await fs.readFile(templatePath, "utf8");
+    const block = findTailwindConfigScript(template);
+    assert.ok(block, "template must contain a tailwind.config block");
+    assert.equal(
+      findSyntaxError(block.body),
+      null,
+      "the canonical block is what every dashboard ships with - if this fails, every future dashboard ships broken",
+    );
+  });
+});
+
 describe("validateAndRepairDashboard", () => {
   let tmpDir;
 

--- a/processor/dashboardValidator.test.js
+++ b/processor/dashboardValidator.test.js
@@ -7,6 +7,7 @@ const os = require("os");
 const {
   validateAndRepairDashboard,
   extractInlineScripts,
+  findTailwindConfigScript,
   findSyntaxError,
 } = require("./dashboardValidator");
 
@@ -27,7 +28,31 @@ const CANONICAL_TAILWIND_BLOCK = `<script>
         }
     </script>`;
 
-const CORRUPTED_TAILWIND_BLOCK = `<script>
+// Real-world corruption from dashboard 2026-05-25-123654 - the leading
+// quote on 'sans-serif' was dropped. This parses cleanly as JavaScript
+// (the parser reads `sans-serif` as `sans - serif`), so PR #99's
+// SyntaxError check missed it. It only fails at runtime with
+// `ReferenceError: sans is not defined`.
+const RUNTIME_FAIL_TAILWIND_BLOCK = `<script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        'ssw-red': { DEFAULT: '#CC4141' },
+                        'ssw-charcoal': { DEFAULT: '#333333' },
+                        'ssw-gray': { 50: '#FAFAFA' }
+                    },
+                    fontFamily: {
+                        'sans': ['Inter', 'Helvetica Neue', 'Helvetica', sans-serif],
+                    }
+                }
+            }
+        }
+    </script>`;
+
+// Original bug shape from issue #98 - dropped leading quote AND kept the
+// trailing one, which produces an unbalanced quote and a real SyntaxError.
+const SYNTAX_FAIL_TAILWIND_BLOCK = `<script>
         tailwind.config = {
             theme: {
                 extend: {
@@ -81,6 +106,20 @@ describe("extractInlineScripts", () => {
   });
 });
 
+describe("findTailwindConfigScript", () => {
+  it("finds the inline block that assigns tailwind.config", () => {
+    const html = buildHtml(CANONICAL_TAILWIND_BLOCK);
+    const block = findTailwindConfigScript(html);
+    assert.ok(block);
+    assert.match(block.body, /tailwind\.config\s*=/);
+  });
+
+  it("returns null when no tailwind.config block is present", () => {
+    const html = `<html><body><script>var x = 1;</script></body></html>`;
+    assert.equal(findTailwindConfigScript(html), null);
+  });
+});
+
 describe("findSyntaxError", () => {
   it("returns null for valid JS", () => {
     assert.equal(findSyntaxError("var x = 1; x + 2;"), null);
@@ -90,22 +129,19 @@ describe("findSyntaxError", () => {
     assert.equal(findSyntaxError("tailwind.config = { theme: {} };"), null);
   });
 
-  it("returns null for the canonical tailwind.config block body", () => {
-    const body = CANONICAL_TAILWIND_BLOCK.replace(/^<script>|<\/script>$/g, "");
-    assert.equal(findSyntaxError(body), null);
-  });
-
-  it("returns a SyntaxError for the corrupted sans-serif typo", () => {
-    const body = CORRUPTED_TAILWIND_BLOCK.replace(/^<script>|<\/script>$/g, "");
-    const err = findSyntaxError(body);
-    assert.ok(err, "expected a syntax error");
-    assert.equal(err.name, "SyntaxError");
-  });
-
   it("returns a SyntaxError for unbalanced braces", () => {
     const err = findSyntaxError("var x = { foo: 1");
     assert.ok(err);
     assert.equal(err.name, "SyntaxError");
+  });
+
+  it("does NOT flag the runtime-only corruption (unquoted sans-serif)", () => {
+    const body = RUNTIME_FAIL_TAILWIND_BLOCK.replace(/^<script>|<\/script>$/g, "");
+    assert.equal(
+      findSyntaxError(body),
+      null,
+      "unquoted sans-serif parses as `sans - serif`, so SyntaxError check cannot catch it - this is why the always-overwrite strategy is needed",
+    );
   });
 });
 
@@ -120,7 +156,7 @@ describe("validateAndRepairDashboard", () => {
     await fs.rm(tmpDir, { recursive: true, force: true });
   });
 
-  it("returns ok=true, repaired=false for a clean dashboard", async () => {
+  it("returns repaired=false and leaves the file untouched when block already matches template", async () => {
     const dashboardPath = path.join(tmpDir, "clean.html");
     const templatePath = path.join(tmpDir, "template.html");
     const cleanHtml = buildHtml(CANONICAL_TAILWIND_BLOCK);
@@ -131,49 +167,70 @@ describe("validateAndRepairDashboard", () => {
     assert.deepEqual(result, { ok: true, repaired: false });
 
     const after = await fs.readFile(dashboardPath, "utf8");
-    assert.equal(after, cleanHtml, "clean dashboard must not be rewritten");
+    assert.equal(after, cleanHtml, "byte-identical dashboard must not be rewritten");
   });
 
-  it("repairs a dashboard with a corrupted tailwind.config block", async () => {
-    const dashboardPath = path.join(tmpDir, "corrupt.html");
-    const templatePath = path.join(tmpDir, "template-corrupt.html");
-    const corruptHtml = buildHtml(CORRUPTED_TAILWIND_BLOCK);
+  it("repairs the runtime-only corruption (unquoted sans-serif) that PR #99 missed", async () => {
+    const dashboardPath = path.join(tmpDir, "runtime-fail.html");
+    const templatePath = path.join(tmpDir, "template-runtime.html");
+    const corruptHtml = buildHtml(RUNTIME_FAIL_TAILWIND_BLOCK);
     const cleanHtml = buildHtml(CANONICAL_TAILWIND_BLOCK);
     await fs.writeFile(dashboardPath, corruptHtml);
     await fs.writeFile(templatePath, cleanHtml);
 
     const result = await validateAndRepairDashboard(dashboardPath, templatePath);
-    assert.equal(result.ok, true);
-    assert.equal(result.repaired, true);
+    assert.deepEqual(result, { ok: true, repaired: true });
 
     const after = await fs.readFile(dashboardPath, "utf8");
     assert.match(after, /'sans-serif'/, "repaired file must contain quoted sans-serif");
-    assert.doesNotMatch(after, /, sans-serif']/, "corruption must be gone");
-
-    const scripts = extractInlineScripts(after);
-    for (const s of scripts) {
-      assert.equal(findSyntaxError(s.body), null, "all scripts must parse after repair");
-    }
+    assert.doesNotMatch(after, /, sans-serif\]/, "unquoted sans-serif must be gone");
   });
 
-  it("returns ok=false when corruption is outside the tailwind.config block", async () => {
-    const dashboardPath = path.join(tmpDir, "other-error.html");
-    const templatePath = path.join(tmpDir, "template-other.html");
-    const otherCorruption = `<!DOCTYPE html>
-<html><head>
-${CANONICAL_TAILWIND_BLOCK}
-</head><body>
-<script>
-  var broken = { foo: 1
-</script>
-</body></html>`;
+  it("repairs the original SyntaxError corruption from issue #98", async () => {
+    const dashboardPath = path.join(tmpDir, "syntax-fail.html");
+    const templatePath = path.join(tmpDir, "template-syntax.html");
+    const corruptHtml = buildHtml(SYNTAX_FAIL_TAILWIND_BLOCK);
     const cleanHtml = buildHtml(CANONICAL_TAILWIND_BLOCK);
-    await fs.writeFile(dashboardPath, otherCorruption);
+    await fs.writeFile(dashboardPath, corruptHtml);
     await fs.writeFile(templatePath, cleanHtml);
 
     const result = await validateAndRepairDashboard(dashboardPath, templatePath);
+    assert.deepEqual(result, { ok: true, repaired: true });
+
+    const after = await fs.readFile(dashboardPath, "utf8");
+    const block = findTailwindConfigScript(after);
+    assert.equal(findSyntaxError(block.body), null);
+  });
+
+  it("repairs the tailwind block even when an unrelated script is also broken", async () => {
+    const dashboardPath = path.join(tmpDir, "mixed-corruption.html");
+    const templatePath = path.join(tmpDir, "template-mixed.html");
+    const corruptHtml = `<!DOCTYPE html>
+<html><head>
+${RUNTIME_FAIL_TAILWIND_BLOCK}
+</head><body>
+<script>var broken = { foo: 1</script>
+</body></html>`;
+    await fs.writeFile(dashboardPath, corruptHtml);
+    await fs.writeFile(templatePath, buildHtml(CANONICAL_TAILWIND_BLOCK));
+
+    const result = await validateAndRepairDashboard(dashboardPath, templatePath);
+    assert.deepEqual(result, { ok: true, repaired: true });
+
+    const after = await fs.readFile(dashboardPath, "utf8");
+    const tailwindBlock = findTailwindConfigScript(after);
+    assert.match(tailwindBlock.body, /'sans-serif'/);
+    assert.match(after, /var broken = \{ foo: 1/, "unrelated broken script is left intact (we have no canonical version for it)");
+  });
+
+  it("returns ok=false when the dashboard has no tailwind.config block at all", async () => {
+    const dashboardPath = path.join(tmpDir, "no-tailwind.html");
+    const templatePath = path.join(tmpDir, "template-no-tw.html");
+    await fs.writeFile(dashboardPath, `<html><body><p>nothing here</p></body></html>`);
+    await fs.writeFile(templatePath, buildHtml(CANONICAL_TAILWIND_BLOCK));
+
+    const result = await validateAndRepairDashboard(dashboardPath, templatePath);
     assert.equal(result.ok, false);
-    assert.equal(result.repaired, false);
-    assert.equal(result.reason, "corruption-outside-tailwind-block");
+    assert.equal(result.reason, "no-tailwind-block-in-dashboard");
   });
 });


### PR DESCRIPTION
## 📝 Summary of Changes

Corresponding issue: #123
- Dashboards can no longer ship with a broken `tailwind.config` block. The inline block is now stamped from the canonical template every time instead of being detected-and-repaired only when its syntax fails to parse.

### 🤷‍♂️ Why
PR #99 caught `SyntaxError`s in the tailwind block but missed runtime-only failures - an unquoted `sans-serif` parses cleanly as `sans - serif`, so `new Function(body)` returned OK and a visibly-broken dashboard shipped at https://dashboards.sswtiger.com/ssw-ai/2026-05-25-123654 with the exact symptom from #98.

The tailwind block is pure static styling config with no per-meeting data, so the model has no business regenerating it. Overwriting unconditionally makes the entire bug class impossible by construction, rather than chasing each new shape of typo with a new detector.

### 🧪 Test plan
- [x] Unit tests cover: byte-identical block left untouched, runtime-only `sans-serif` corruption repaired, original `SyntaxError` corruption from #98 repaired, mixed corruption (tailwind block + unrelated broken script) repairs tailwind and leaves the rest alone, missing tailwind block reports `ok: false` (56/56 pass)
- [x] End-to-end smoke test: validator repairs the actual broken dashboard from https://dashboards.sswtiger.com/ssw-ai/2026-05-25-123654
- [ ] Reviewer: process a fresh transcript end-to-end and confirm a clean dashboard's tailwind block is byte-identical to the template's after the validator step
- [ ] Reviewer: optionally hand-corrupt a generated `index.html` with any tailwind typo (quoted or unquoted) and confirm it is replaced before deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)