### PR TITLE
Make People feedback prominent and scannable with topic prefixes

### DIFF
--- a/.claude/agents/consolidator.md
+++ b/.claude/agents/consolidator.md
@@ -265,7 +265,15 @@ Note what's missing:
         "speakingTimePercent": 28,
         "valueScore": 6,
         "keyFinding": "Dominated discussion but lower value-per-minute than quieter participants",
-        "feedbackHighlight": "Interrupted others 5 times; needs to create more space"
+        "strengths": [
+          "Facilitation - kept the agenda moving with no dead air",
+          "Good questions - clarifying question at 52:00 unblocked the dependency call"
+        ],
+        "feedback": [
+          "Interruptions - cut across others 5 times; needs to create more space",
+          "Airtime - answered questions aimed at others; let the experts speak",
+          "Time discipline - 'quick clarifications' averaged 3 minutes each"
+        ]
       },
       {
         "id": "p2",
@@ -277,7 +285,14 @@ Note what's missing:
         "speakingTimePercent": 18,
         "valueScore": 8,
         "keyFinding": "Highest value-per-minute but systematically underutilized",
-        "feedbackHighlight": "Auth expertise was ignored while team spent 15 minutes on auth bug"
+        "strengths": [
+          "Efficiency - every word counted, no filler",
+          "Sharp questions - one question at 34:00 exposed a flaw nobody else caught"
+        ],
+        "feedback": [
+          "Speak up - auth expertise sat unused while the team spent 15 minutes on an auth bug",
+          "Push back - hold your ground when talked over; the point was important"
+        ]
       }
     ],
     "unidentified": [
@@ -502,6 +517,15 @@ Rules (each shown as right-form not wrong-form):
 - **No-product fallback is `General`.** `General - Updated contribution guide for new joiners` not `Misc - ...`, not `Other - ...`, not an item with no prefix at all.
 - **Cross-cutting items pick the primary product.** `Cheetah - Updated shared auth flow` not `Cheetah/Crystal Ball - ...` and not `Multiple - ...`.
 - **The prefix is prepended; the rest is unchanged.** `Cheetah - Shipped onboarding flow redesign (Alice)` not `Shipped onboarding flow redesign (Alice)`. The trailing `(owner)` annotation is preserved as-is.
+
+### Participant strengths & feedback (applies to `participants.canonical[].strengths[]` and `participants.canonical[].feedback[]`)
+
+Each canonical participant carries two short bulleted lists for the People tab. These are the primary content of the People cards, so keep them sharp:
+
+- **`strengths`** — 2-3 items, drawn from the people-analyzer's `whatTheyDidWell`.
+- **`feedback`** — 2-3 items, drawn from the people-analyzer's `whatTheyNeedToHear`. Pick the most actionable points; do NOT collapse them into a single sentence. (This replaces the old single-string `feedbackHighlight`.)
+- **Preserve the `<Topic> - ` prefix on every item.** The people-analyzer prefixes each point with a short topic label (e.g. `Interruptions - ...`, `Facilitation - ...`) so cards are scannable at a glance. Carry that prefix through unchanged; never strip it. If an upstream item is missing a prefix, add a fitting short label rather than emitting a bare point.
+- **`keyFinding` stays a single sentence** — it is the one-line headline above the lists, not part of either list.
 
 ## Your Standards
 

--- a/.claude/agents/consolidator.md
+++ b/.claude/agents/consolidator.md
@@ -286,12 +286,13 @@ Note what's missing:
         "valueScore": 8,
         "keyFinding": "Highest value-per-minute but systematically underutilized",
         "strengths": [
-          "Efficiency - every word counted, no filler",
-          "Sharp questions - one question at 34:00 exposed a flaw nobody else caught"
+          "Sharp questions - one question at 34:00 exposed a flaw nobody else caught",
+          "Efficiency - every word counted, no filler"
         ],
         "feedback": [
           "Speak up - auth expertise sat unused while the team spent 15 minutes on an auth bug",
-          "Push back - hold your ground when talked over; the point was important"
+          "Push back - hold your ground when talked over; the point was important",
+          "Initiative - you don't need permission to contribute"
         ]
       }
     ],
@@ -522,10 +523,10 @@ Rules (each shown as right-form not wrong-form):
 
 Each canonical participant carries two short bulleted lists for the People tab. These are the primary content of the People cards, so keep them sharp:
 
-- **`strengths`** — 2-3 items, drawn from the people-analyzer's `whatTheyDidWell`.
-- **`feedback`** — 2-3 items, drawn from the people-analyzer's `whatTheyNeedToHear`. Pick the most actionable points; do NOT collapse them into a single sentence. (This replaces the old single-string `feedbackHighlight`.)
+- **`strengths`** - 2-3 items, drawn from the people-analyzer's `whatTheyDidWell`.
+- **`feedback`** - 2-3 items, drawn from the people-analyzer's `whatTheyNeedToHear`. Pick the most actionable points; do NOT collapse them into a single sentence. (This replaces the old single-string `feedbackHighlight`.)
 - **Preserve the `<Topic> - ` prefix on every item.** The people-analyzer prefixes each point with a short topic label (e.g. `Interruptions - ...`, `Facilitation - ...`) so cards are scannable at a glance. Carry that prefix through unchanged; never strip it. If an upstream item is missing a prefix, add a fitting short label rather than emitting a bare point.
-- **`keyFinding` stays a single sentence** — it is the one-line headline above the lists, not part of either list.
+- **`keyFinding` stays a single sentence** - it is the one-line headline above the lists, not part of either list.
 
 ## Your Standards
 

--- a/.claude/agents/people-analyzer.md
+++ b/.claude/agents/people-analyzer.md
@@ -92,6 +92,19 @@ For each participant, provide:
 #### Scrum Role Specific Feedback
 - Tips on how to become a better Product Owner/Scrum Master/Software Developer etc.
 
+#### Point Prefixes (for scannability)
+
+Every item in `whatTheyDidWell` and `whatTheyNeedToHear` MUST begin with a **short topic label** (1-3 words) that captures what the point is about, followed by ` - ` (space, hyphen, space), then the point itself. This lets a reader scan the card and tell what each point covers at a glance, the same way Overview items are prefixed with their product.
+
+Format: `<Topic> - <the point you would have written anyway>`
+
+Rules (each shown as right-form not wrong-form):
+
+- **The label names the theme, not the verdict.** `Facilitation - ran the meeting but skipped key moments` not `Bad - skipped key moments`, not `Issue 1 - ...`.
+- **Keep labels short and concrete.** `Filler cues`, `Interruptions`, `Preparation`, `Buffer policy`, `Communication`, `Technical depth`. Not full sentences, not single vague words like `Improvement`.
+- **The prefix is prepended; the point is unchanged.** `Interruptions - you talked over Bob 3 times in 10 minutes` not just `you talked over Bob 3 times in 10 minutes`.
+- **Distinct labels within a card.** Don't reuse the same label for two points on the same person; pick the more specific theme for each.
+
 ### 5. Team Dysfunction Analysis
 
 #### Power Imbalances
@@ -153,14 +166,14 @@ For each participant, provide:
       },
       
       "whatTheyDidWell": [
-        "Summarized sprint goals clearly at 45:00",
-        "Asked the right question about the dependency at 52:00"
+        "Facilitation - summarized sprint goals clearly at 45:00",
+        "Good questions - asked the right question about the dependency at 52:00"
       ],
       
       "whatTheyNeedToHear": [
-        "You interrupted Bob 3 times in 10 minutes - he had valid points you missed",
-        "You answered questions directed at others - let the experts speak",
-        "Your 'quick clarifications' averaged 3 minutes each - that's not quick"
+        "Interruptions - you interrupted Bob 3 times in 10 minutes; he had valid points you missed",
+        "Airtime - you answered questions directed at others; let the experts speak",
+        "Time discipline - your 'quick clarifications' averaged 3 minutes each, that's not quick"
       ],
       
       "uncomfortableQuestion": "Would this meeting have been better if you'd spoken 40% less?",
@@ -193,14 +206,14 @@ For each participant, provide:
       },
       
       "whatTheyDidWell": [
-        "Their one question at 34:00 exposed a critical flaw nobody else caught",
-        "Efficient - every word counted"
+        "Sharp questions - their one question at 34:00 exposed a critical flaw nobody else caught",
+        "Efficiency - every word counted, no filler"
       ],
       
       "whatTheyNeedToHear": [
-        "You have expertise the team needs - your silence is costing them",
-        "When Alice talked over you at 28:00, push back - your point was important",
-        "You don't need permission to contribute"
+        "Speak up - you have expertise the team needs; your silence is costing them",
+        "Push back - when Alice talked over you at 28:00, hold your ground, your point was important",
+        "Permission - you don't need it to contribute"
       ],
       
       "costOfTheirSilence": "The team made a decision without Charlie's input on the auth flow - Charlie is the auth expert",

--- a/.claude/agents/people-analyzer.md
+++ b/.claude/agents/people-analyzer.md
@@ -213,7 +213,7 @@ Rules (each shown as right-form not wrong-form):
       "whatTheyNeedToHear": [
         "Speak up - you have expertise the team needs; your silence is costing them",
         "Push back - when Alice talked over you at 28:00, hold your ground, your point was important",
-        "Permission - you don't need it to contribute"
+        "Initiative - you don't need permission to contribute"
       ],
       
       "costOfTheirSilence": "The team made a decision without Charlie's input on the auth flow - Charlie is the auth expert",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -221,10 +221,11 @@ All sections below use `<li>` bullet points inside `<ul>` — consistent style t
 - Card for each participant **(canonical name with role as subtitle)**
 - **Profile photo from SSW People** (with fallback for non-SSW participants)
 - Speaking time vs. value contribution
-- **Written feedback is the focus of each card.** Strengths and Feedback are the primary content, rendered as prominent coloured bands (green for Strengths, amber for Feedback) in larger text below the rating — NOT as small grey footnotes. Render each from the participant's `strengths[]` and `feedback[]` lists in `consolidated.json` (2-3 bullets each). Feedback is a bulleted list, not a single paragraph.
-  - **Every bullet leads with a bold topic prefix** so the card is scannable at a glance, e.g. `<span class="font-semibold">Interruptions</span> - cut across others 5 times`. The prefix comes from the consolidated data (`<Topic> - point`); render the part before the ` - ` bold. This mirrors the `<Product> -` prefix on Overview bullets.
+- **Written feedback is the focus of each card.** Strengths and Feedback are the primary content, rendered as prominent coloured bands (green for Strengths, amber for Feedback - including the band heading) in larger text below the rating, NOT as small grey footnotes. Render each from the participant's `strengths[]` and `feedback[]` lists in `consolidated.json` (2-3 bullets each). Feedback is a bulleted list, not a single paragraph.
+  - **Every bullet leads with a bold topic prefix** so the card is scannable at a glance, e.g. `<span class="font-semibold">Interruptions</span> - cut across others 5 times`. The prefix comes from the consolidated data (`<Topic> - point`); render only the text before the **first** ` - ` bold, leaving any later hyphens in the point unbolded. This mirrors the `<Product> -` prefix on Overview bullets.
   - Keep band body text black (`text-ssw-charcoal`); only the heading and left border use accent colours.
-- Value scores are whole numbers out of 10 — no decimals. Avoid 7/10 (too average/non-committal); be more decisive with 6 or 8. Bar color: 8-10 = GREEN, 4-6 = YELLOW, 3 and below = RED. **The rating/bar stays as-is — it is not de-emphasized, just no longer the only thing that stands out.**
+  - **Thin-feedback fallback:** render only the points that exist (1 is fine if that's all there is). If a participant has no strengths or no feedback at all (e.g. a boardroom attendee with minimal individual signal), omit that band entirely rather than render an empty coloured box.
+- Value scores are whole numbers out of 10, no decimals. Avoid 7/10 (too average/non-committal); be more decisive with 6 or 8. Bar color: 8-10 = GREEN, 4-6 = YELLOW, 3 and below = RED. **The rating/bar stays as-is - it is not de-emphasized, just no longer the only thing that stands out.**
 - **Boardroom participants** (identified from invite list + transcript mentions, but no `<v>` tags): include cards with correct names/photos, but note that individual speaking metrics are unavailable
 
 ### Tab 4: Insights
@@ -371,9 +372,9 @@ For each participant card, look up the slug in this order:
                 <div class="flex items-center gap-2">
                     <span class="text-sm text-ssw-gray-600">Value Score:</span>
                     <div class="flex-1 bg-ssw-gray-100 rounded-full h-2">
-                        <div class="bg-ssw-red h-2 rounded-full" style="width: 85%"></div>
+                        <div class="bg-ssw-red h-2 rounded-full" style="width: 80%"></div>
                     </div>
-                    <span class="text-sm font-semibold text-ssw-charcoal">8.5/10</span>
+                    <span class="text-sm font-semibold text-ssw-charcoal">8/10</span>
                 </div>
             </div>
 
@@ -383,7 +384,7 @@ For each participant card, look up the slug in this order:
                 Highest value-per-minute but systematically underutilized
             </p>
 
-            <!-- Strengths (prominent band — the written feedback is the focus of the card) -->
+            <!-- Strengths (prominent band - the written feedback is the focus of the card) -->
             <div class="border-l-4 border-green-400 bg-green-50 rounded-r-lg px-4 py-3 mb-3">
                 <p class="text-sm font-semibold text-green-700 uppercase tracking-wide mb-2">Strengths</p>
                 <ul class="text-base text-ssw-charcoal space-y-2 leading-snug">
@@ -394,10 +395,10 @@ For each participant card, look up the slug in this order:
 
             <!-- Feedback (prominent band) -->
             <div class="border-l-4 border-amber-400 bg-amber-50 rounded-r-lg px-4 py-3">
-                <p class="text-sm font-semibold text-ssw-red uppercase tracking-wide mb-2">Feedback</p>
+                <p class="text-sm font-semibold text-amber-700 uppercase tracking-wide mb-2">Feedback</p>
                 <ul class="text-base text-ssw-charcoal space-y-2 leading-snug">
                     <li>• <span class="font-semibold">Push back</span> - when interrupted, hold your ground; your points matter</li>
-                    <li>• <span class="font-semibold">Permission</span> - don't wait for it to contribute</li>
+                    <li>• <span class="font-semibold">Initiative</span> - you don't need permission to contribute</li>
                 </ul>
             </div>
         </div>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ A single topic (e.g., "John departing") must NOT appear as:
 | **Red-50** | Critical issues only (Hard Truths section, critical risks) | `bg-ssw-red-50` or `bg-red-50` |
 | **SSW Gray** | Neutral info, headers, team dynamics cards | `bg-ssw-gray-50` to `bg-ssw-gray-700` |
 
-Any color NOT in this table is **forbidden** as a background. This means no `bg-blue-*`, no `bg-purple-*`, no `bg-indigo-*`, no `bg-teal-*`, etc. `border-l-4` accent colors may use `border-ssw-red`, `border-amber-400/500`, or `border-ssw-gray-300` for priority indicators.
+Any color NOT in this table is **forbidden** as a background. This means no `bg-blue-*`, no `bg-purple-*`, no `bg-indigo-*`, no `bg-teal-*`, etc. `border-l-4` accent colors may use `border-ssw-red`, `border-amber-400/500`, `border-green-400/500` (positive bands, e.g. People Strengths), or `border-ssw-gray-300` for priority indicators.
 
 ### Tab 1: Overview
 
@@ -221,8 +221,10 @@ All sections below use `<li>` bullet points inside `<ul>` — consistent style t
 - Card for each participant **(canonical name with role as subtitle)**
 - **Profile photo from SSW People** (with fallback for non-SSW participants)
 - Speaking time vs. value contribution
-- Strengths and constructive feedback
-- Value scores are whole numbers out of 10 — no decimals. Avoid 7/10 (too average/non-committal); be more decisive with 6 or 8. Bar color: 8-10 = GREEN, 4-6 = YELLOW, 3 and below = RED
+- **Written feedback is the focus of each card.** Strengths and Feedback are the primary content, rendered as prominent coloured bands (green for Strengths, amber for Feedback) in larger text below the rating — NOT as small grey footnotes. Render each from the participant's `strengths[]` and `feedback[]` lists in `consolidated.json` (2-3 bullets each). Feedback is a bulleted list, not a single paragraph.
+  - **Every bullet leads with a bold topic prefix** so the card is scannable at a glance, e.g. `<span class="font-semibold">Interruptions</span> - cut across others 5 times`. The prefix comes from the consolidated data (`<Topic> - point`); render the part before the ` - ` bold. This mirrors the `<Product> -` prefix on Overview bullets.
+  - Keep band body text black (`text-ssw-charcoal`); only the heading and left border use accent colours.
+- Value scores are whole numbers out of 10 — no decimals. Avoid 7/10 (too average/non-committal); be more decisive with 6 or 8. Bar color: 8-10 = GREEN, 4-6 = YELLOW, 3 and below = RED. **The rating/bar stays as-is — it is not de-emphasized, just no longer the only thing that stands out.**
 - **Boardroom participants** (identified from invite list + transcript mentions, but no `<v>` tags): include cards with correct names/photos, but note that individual speaking metrics are unavailable
 
 ### Tab 4: Insights
@@ -381,21 +383,21 @@ For each participant card, look up the slug in this order:
                 Highest value-per-minute but systematically underutilized
             </p>
 
-            <!-- Strengths -->
-            <div class="mb-2">
-                <p class="text-xs font-semibold text-green-700 uppercase tracking-wide mb-1">Strengths</p>
-                <ul class="text-sm text-ssw-gray-600 space-y-1">
-                    <li>• Efficient communication - every word counted</li>
-                    <li>• Technical expertise highly valuable when consulted</li>
+            <!-- Strengths (prominent band — the written feedback is the focus of the card) -->
+            <div class="border-l-4 border-green-400 bg-green-50 rounded-r-lg px-4 py-3 mb-3">
+                <p class="text-sm font-semibold text-green-700 uppercase tracking-wide mb-2">Strengths</p>
+                <ul class="text-base text-ssw-charcoal space-y-2 leading-snug">
+                    <li>• <span class="font-semibold">Efficiency</span> - every word counted, no filler</li>
+                    <li>• <span class="font-semibold">Technical depth</span> - highly valuable when consulted</li>
                 </ul>
             </div>
 
-            <!-- Feedback -->
-            <div>
-                <p class="text-xs font-semibold text-ssw-red uppercase tracking-wide mb-1">Feedback</p>
-                <ul class="text-sm text-ssw-gray-600 space-y-1">
-                    <li>• Push back when interrupted - your points are important</li>
-                    <li>• Don't wait for permission to contribute</li>
+            <!-- Feedback (prominent band) -->
+            <div class="border-l-4 border-amber-400 bg-amber-50 rounded-r-lg px-4 py-3">
+                <p class="text-sm font-semibold text-ssw-red uppercase tracking-wide mb-2">Feedback</p>
+                <ul class="text-base text-ssw-charcoal space-y-2 leading-snug">
+                    <li>• <span class="font-semibold">Push back</span> - when interrupted, hold your ground; your points matter</li>
+                    <li>• <span class="font-semibold">Permission</span> - don't wait for it to contribute</li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
## 📝 Summary of Changes

Corresponding issue: #110
- The People page now leads with the written feedback: Strengths and Feedback render as prominent green/amber bands in larger text below the rating, instead of small grey footnotes.
- Every strength and feedback point starts with a short bold topic prefix (e.g. `Interruptions - ...`), so each card is scannable at a glance during a sprint review.
- Feedback now shows as a 2-3 point list rather than a single highlight sentence. The numeric rating and value bar are unchanged.

### 🤷‍♂️ Why
In sprint reviews the valuable part of the People page is the written feedback and strengths, not the numeric rating. They were previously rendered as small grey text that was easy to skim past. Making them the visual focus, with a topic prefix per point, lets the team read each person's feedback at a glance.

### 🧪 Test plan
- [x] Confirmed the People card markup is fully agent-generated from `CLAUDE.md`, so the change is prompt/template only.
- [x] Confirmed no other agent, skill, or the dashboard template still depends on the removed `feedbackHighlight` field.
- [x] Re-run a past meeting through the pipeline and confirm the generated People cards show the coloured bands, larger text, and per-point prefixes.

> Note: cross-sprint feedback history (issue #110 ACs 3 and 4) is intentionally out of scope here - it depends on the per-sprint persistence work tracked in #45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)