### PR TITLE
Add Cross-Team Announcements section to dashboards

### DIFF
--- a/.claude/agents/consolidator.md
+++ b/.claude/agents/consolidator.md
@@ -112,6 +112,7 @@ Each output section has a **single question it answers**. Content goes in whiche
 | `keyDecisions` | "What were the top 1-3 decisions made in this meeting?" |
 | `doneThisSprint` | "What was accomplished or resolved THIS sprint? (excluding decisions)" |
 | `nextSteps` | "What specific tasks must be done NEXT, by whom, by when?" |
+| `crossTeamAnnouncements` | "What from this meeting must developers OUTSIDE this team hear about?" — **audience digest; the ONE permitted exception to single-section placement** (see rules below) |
 | `consolidatedTimeline` | "What happened chronologically and how was time spent?" |
 | `participants` | "How did each individual contribute?" |
 | `consolidatedInsights` | "What hidden patterns, risks, or elephants exist beneath the surface?" |
@@ -461,6 +462,19 @@ Note what's missing:
       "Previous completion rate suggests 4-5 of these will not get done"
     ]
   },
+
+  "crossTeamAnnouncements": {
+    "NOTE": "Audience digest for developers OUTSIDE this team. Max 5 items. Each item re-states a decision/done/next item in plain language - this is the ONE permitted duplication. Empty items array is valid and common.",
+    "items": [
+      {
+        "id": "xt1",
+        "announcement": "Cheetah - API rate limiting now returns 429 instead of 503",
+        "impact": "Check any retry/error-handling logic keyed on 503 responses",
+        "category": "api-change",
+        "sourceId": "kd3"
+      }
+    ]
+  },
   
   "hardTruths": [
     "Max 3 items. Each is 1-2 sentences. Punchy, direct, no essays.",
@@ -518,6 +532,30 @@ Rules (each shown as right-form not wrong-form):
 - **No-product fallback is `General`.** `General - Updated contribution guide for new joiners` not `Misc - ...`, not `Other - ...`, not an item with no prefix at all.
 - **Cross-cutting items pick the primary product.** `Cheetah - Updated shared auth flow` not `Cheetah/Crystal Ball - ...` and not `Multiple - ...`.
 - **The prefix is prepended; the rest is unchanged.** `Cheetah - Shipped onboarding flow redesign (Alice)` not `Shipped onboarding flow redesign (Alice)`. The trailing `(owner)` annotation is preserved as-is.
+
+### Cross-team announcements (applies to `crossTeamAnnouncements.items[]`)
+
+This section is a **digest for a different audience** - developers who are NOT on this team and do not attend these meetings. It is the ONE exception to the "each topic appears in exactly one section" rule: every announcement here is a plain-language re-statement of an item that ALSO lives in `keyDecisions`, `doneThisSprint`, or `nextSteps` (link it via `sourceId`).
+
+**Include an item ONLY if an outside developer would change something or be caught out by not knowing.** Qualifying categories:
+
+- `api-change` - API/runtime behavior changes (status codes, rate limits, response shapes, timeouts)
+- `auth` - authentication/authorization changes (provider migrations, token handling, login flows)
+- `runtime` - version bumps with compatibility impact (Node/framework/LTS alignment)
+- `rename` - renames and moves (templates, packages, repos, commands) that break links or muscle memory
+- `deprecation` - anything being sunset, with the replacement
+- `release` - new tools/features now available to other teams (CLIs, rollouts to all users)
+- `direction` - strategic direction changes that affect what outsiders should build on
+- `security` - security patches outsiders should pick up
+
+**Exclude:** internal task assignments, sprint goals, team process changes, progress percentages, anything an outsider cannot act on.
+
+**Writing rules:**
+
+- Keep the `<Product> - ` prefix (same rule as the other item lists).
+- **Plain language, no team shorthand.** An outside reader has not heard of internal epic names, PBI numbers, or nicknames. `TinaCMS - The starter template formerly called "bare bones" is now "React starter"` not `Renamed bare bones per kd1`.
+- `impact` says what the outside dev should DO or CHECK - one sentence, imperative.
+- Max 5 items. **An empty list is the normal case** - most meetings produce none. Never pad.
 
 ### Participant strengths & feedback (applies to `participants.canonical[].strengths[]` and `participants.canonical[].feedback[]`)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,7 +148,7 @@ Each tab answers ONE question. Before writing content for any section, ask: "Whi
 
 | Tab | The ONE Question It Answers | Owns exclusively |
 |---|---|---|
-| **Overview** | "What happened, what's done, and what's next?" | Factual summary, done items, next steps |
+| **Overview** | "What happened, what's done, and what's next?" | Factual summary, done items, next steps, cross-team announcements (an audience digest — the ONE permitted re-statement of items already in this tab) |
 | **Timeline** | "When did things happen and how was time spent?" | Chronological flow, time allocation, pacing |
 | **People** | "How did each individual contribute?" | Individual performance, feedback, person-specific issues |
 | **Insights** | "What's hidden beneath the surface?" | Risks, elephants, patterns, opportunities, hard truths |
@@ -204,6 +204,7 @@ All sections below use `<li>` bullet points inside `<ul>` — consistent style t
 
 - **Meeting Summary** — **brief** factual bullet points, max 5 bullets. Each bullet is one short sentence. No commentary or analysis. Example: `<li>Sprint 98 delivered 35 points across 12 PBIs</li>`
 - **Key Decisions** — choices between alternatives, **max 3 bullets** (e.g., "Use SSW Identity Server instead of building from scratch"). Sprint goal setting is NOT a key decision — it belongs in the summary. Each bullet starts with `<Product> - ` (see `consolidator.md` > `Item product prefix`).
+- **Cross-Team Announcements** — rendered from `consolidated.json -> crossTeamAnnouncements.items[]` into the `{{CROSS_TEAM_ANNOUNCEMENTS}}` placeholder. Each item is a `<li>` with the announcement, followed by the impact in smaller gray text: `<li>📣 TinaCMS - Rate limiting now returns 429 instead of 503 <span class="text-sm text-ssw-gray-500">— check retry logic keyed on 503</span></li>`. These items are a plain-language digest for developers outside the team — this is the ONE permitted overlap with Key Decisions / Done This Sprint / Next Steps (see `consolidator.md` > `Cross-team announcements`). **If the list is empty, REMOVE the entire Cross-Team Announcements `<section>` from the output HTML** — do not render an empty box.
 - **Done This Sprint** — outcomes, features completed/demoed, issues resolved. Each item as a plain `<li>` with owner in parentheses. No emoji icons. Do NOT repeat decisions already in Key Decisions. Each bullet starts with `<Product> - ` (see `consolidator.md` > `Item product prefix`).
 - **Next Steps** — work items for next sprint and other follow-up actions, as plain `<li>` bullets with owner **(canonical names!)**. No emoji icons. Each bullet starts with `<Product> - ` (see `consolidator.md` > `Item product prefix`).
 - **Hard truths** — **MAX 2 items, each max 2 sentences.** Keep them punchy and direct, not paragraph-length essays. ONLY high-level synthesis that genuinely doesn't fit in Insights, People, or Trends.

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -301,6 +301,18 @@
                     </section>
                 </div>
 
+                <!-- Cross-Team Announcements -->
+                <section class="mt-6 bg-white rounded-xl shadow-sm ssw-card p-6">
+                    <h2 class="text-lg text-ssw-charcoal mb-3 flex items-center">
+                        <span class="w-3 h-3 bg-ssw-red rounded-full mr-2"></span>
+                        📣 Cross-Team Announcements
+                    </h2>
+                    <p class="text-sm text-ssw-gray-500 mb-3">Changes developers outside this team should know about</p>
+                    <ul class="space-y-2 text-ssw-gray-600">
+                        {{CROSS_TEAM_ANNOUNCEMENTS}}
+                    </ul>
+                </section>
+
                 <!-- Done This Sprint -->
                 <section class="mt-6 bg-white rounded-xl shadow-sm ssw-card p-6">
                     <h2 class="text-lg text-ssw-charcoal mb-3 flex items-center">


### PR DESCRIPTION
## What

Sprint items are written for the team, so changes **other teams** need to hear about (API behavior changes, auth migrations, version bumps, renames, deprecations, rollouts) get buried in internal shorthand. This adds a **📣 Cross-Team Announcements** section to the dashboard Overview tab.

## How

- **`.claude/agents/consolidator.md`** — new `crossTeamAnnouncements` output section: max 5 plain-language items, each with `announcement` (`<Product> - ...` prefix kept), an imperative `impact` ("check retry logic keyed on 503"), a `category` (api-change / auth / runtime / rename / deprecation / release / direction / security), and a `sourceId` linking back to the decision/done/next item it digests. Explicitly documented as the ONE permitted exception to the single-section dedup rule, since it re-states items for a different audience. Empty list is the expected normal case — no padding.
- **`CLAUDE.md`** — Overview tab spec: render the digest between Key Decisions and Done This Sprint; remove the section entirely when there are no announcements.
- **`templates/dashboard.html`** — `{{CROSS_TEAM_ANNOUNCEMENTS}}` section markup.

## Notes

Takes effect for meetings processed after this merges (container `latest` rebuilds automatically). Existing dashboards are unaffected until re-processed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)